### PR TITLE
feat(tk-upload): Add invalid and loading state demos

### DIFF
--- a/packages/docs/src/docs-files/tk-upload/Examples/State.tsx
+++ b/packages/docs/src/docs-files/tk-upload/Examples/State.tsx
@@ -3,14 +3,22 @@ import FeatureDemo from '../../../components/FeatureDemo';
 import React from 'react';
 
 const State = () => {
-  const reactCode = `<TkUpload disabled={true}></TkUpload>`;
+  const reactCode = `<TkUpload disabled={true}></TkUpload>
+<TkUpload invalid={true} error="This is an error message"></TkUpload>
+<TkUpload loading={true}></TkUpload>`;
 
-  const vueCode = `<TkUpload :disabled="true"></TkUpload>`;
+  const vueCode = `<TkUpload :disabled="true"></TkUpload>
+<TkUpload :invalid="true" error="This is an error message"></TkUpload>
+<TkUpload :loading="true"></TkUpload>`;
 
   const demo = (
     <div>
       <label>Disabled</label>
       <TkUpload disabled={true}></TkUpload>
+      <label>Invalid and Error</label>
+      <TkUpload invalid={true} error="This is an error message"></TkUpload>
+      <label>Loading</label>
+      <TkUpload loading={true}></TkUpload>
     </div>
   );
 

--- a/packages/docs/src/docs-files/tk-upload/body.mdx
+++ b/packages/docs/src/docs-files/tk-upload/body.mdx
@@ -10,7 +10,7 @@ import Type from "./Examples/Type"
 
 ## State
 
-This demo showcases the disabled and invalid states of the upload component.
+This demo showcases the disabled, invalid and loading states of the upload component.
 
 <State />
 


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This pull request adds new examples for the TkUpload component, illustrating its invalid and loading states. The documentation has been updated to reflect these enhancements, improving the clarity of the component's functionality and overall user experience.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>