### PR TITLE
fix(tk-table): Fix sorting icon when clearSorting method is called

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -348,7 +348,7 @@ export class TkTable implements ComponentInterface {
       this.sortField = null;
       this.sortOrder = null;
       this.currentPage = 1;
-      // tüm sort iconlar default duruma getirilir
+      // all sort icons are reset to their default state
       this.el.shadowRoot.querySelectorAll('thead th .tk-table-head-cell .sort-icon').forEach((icon: HTMLTkIconElement) => (icon.icon = 'swap_vert'));
 
       if (this.paginationMethod !== 'server') {


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the tk-table component by improving the functionality of sorting icons, ensuring they reset to their default state when the clearSorting method is invoked. This change aims to provide a clearer visual indication of the sorting state, thereby improving user experience without introducing new features or breaking changes.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>