### PR TITLE
fix(tk-pagination): Hide page and item numbers for empty data

### DIFF
--- a/packages/core/src/components/tk-pagination/tk-pagination.tsx
+++ b/packages/core/src/components/tk-pagination/tk-pagination.tsx
@@ -241,7 +241,7 @@ export class TkPagination implements ComponentInterface {
           </span>
         );
       } else {
-        tagContent = (
+        tagContent = totalPages > 0 && (
           <Fragment>
             <span class="tk-pagination-tag-label">
               page: {this.internalCurrentPage} of {totalPages}


### PR DESCRIPTION
Hide page and item numbers for empty data 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the tk-pagination component by hiding page and item numbers when no data is available, enhancing the user interface and experience during navigation through empty datasets.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on UI behavior, making the review process relatively simple.
</div>