### PR TITLE
fix(tk-table): Checkbox and icons are disabled

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -840,7 +840,7 @@ export class TkTable implements ComponentInterface {
     if (this.selectionMode === 'checkbox') {
       selectionTh = (
         <th style={{ width: '20px', maxWidth: '20px' }} class="non-text">
-          <tk-checkbox ref={el => (this.refSelectAll = el)} onTk-change={e => this.handleSelectAll(e.detail)}></tk-checkbox>
+          <tk-checkbox disabled={!(this.renderData.length > 0)} ref={el => (this.refSelectAll = el)} onTk-change={e => this.handleSelectAll(e.detail)}></tk-checkbox>{' '}
         </th>
       );
     } else if (this.selectionMode === 'radio') {
@@ -870,7 +870,7 @@ export class TkTable implements ComponentInterface {
                   class: classNames('sort-icon'),
                   variant: null,
                   ref: (el: any) => (refSortIcon = el),
-                  onClick: () => this.handleSortIconClick(refSortIcon, col),
+                  onClick: () => this.renderData?.length > 0 && this.handleSortIconClick(refSortIcon, col),
                 })}
               />
             );
@@ -882,7 +882,7 @@ export class TkTable implements ComponentInterface {
                     class: classNames('filter-icon'),
                     variant: null,
                     ref: (el: any) => (refSearchIcon = el),
-                    onClick: () => this.handleSearchIconClick(refSearchIcon, col.field),
+                    onClick: () => this.renderData?.length > 0 && this.handleSearchIconClick(refSearchIcon, col.field),
                   })}
                 />
               );


### PR DESCRIPTION
Checkbox and icons are disabled 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the tk-table component by disabling the checkbox and sort/search icons when no render data is available. This change enhances user experience by preventing interactions that could lead to errors, thereby improving the component's robustness.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>