### PR TITLE
fix(tk-pagination): Data pagination has disabled for empty data

### DIFF
--- a/packages/core/src/components/tk-pagination/tk-pagination.tsx
+++ b/packages/core/src/components/tk-pagination/tk-pagination.tsx
@@ -56,7 +56,6 @@ export class TkPagination implements ComponentInterface {
 
   /**
    * The mode of the pagination
-   * @defaultValue 'outlined'
    */
   @Prop() mode: 'compact' | 'compact-expanded';
 
@@ -358,14 +357,16 @@ export class TkPagination implements ComponentInterface {
     const totalPages = this.getTotalPages();
 
     return (
-      <div class="tk-pagination-container">
-        <div class="tk-pagination-start">{this.renderTag(totalPages)}</div>
-        {this.renderContent(totalPages)}
-        <div class="tk-pagination-end">
-          {this.renderSelect()}
-          {this.renderInput(totalPages)}
+      totalPages > 0 && (
+        <div class="tk-pagination-container">
+          <div class="tk-pagination-start">{this.renderTag(totalPages)}</div>
+          {this.renderContent(totalPages)}
+          <div class="tk-pagination-end">
+            {this.renderSelect()}
+            {this.renderInput(totalPages)}
+          </div>
         </div>
-      </div>
+      )
     );
   }
 }


### PR DESCRIPTION
Data pagination has disabled for empty data 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the pagination component by preventing it from rendering when there are no pages to display, improving user experience by avoiding unnecessary UI elements.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>