### PR TITLE
fix(tk-datepicker): Size prop added for label

### DIFF
--- a/packages/core/src/components/tk-datepicker/tk-datepicker.tsx
+++ b/packages/core/src/components/tk-datepicker/tk-datepicker.tsx
@@ -95,7 +95,7 @@ export class TkDatePicker {
    * Defines the size for the label
    * @defaultValue base
    */
-  @Prop() labelSize: 'large' | 'base' | 'small' = 'base';
+  @Prop() size: 'large' | 'base' | 'small' = 'base';
 
   /**
    * Whether the datepicker is disabled
@@ -1418,9 +1418,9 @@ export class TkDatePicker {
       <tk-input
         ref={el => (this.inputRef = el as HTMLTkInputElement)}
         label={this.label}
+        size={this.size}
         mode="text"
         icon="calendar_month"
-        size={this.labelSize}
         class={classNames('tk-datepicker-input', { 'tk-table-input': this.el.classList.contains('tk-table-datepicker') })}
         name={this.name}
         hint={this.hint}

--- a/packages/core/src/components/tk-datepicker/tk-datepicker.tsx
+++ b/packages/core/src/components/tk-datepicker/tk-datepicker.tsx
@@ -91,6 +91,11 @@ export class TkDatePicker {
    * Defines the label for the input
    */
   @Prop() label: string;
+  /**
+   * Defines the size for the label
+   * @defaultValue base
+   */
+  @Prop() labelSize: 'large' | 'base' | 'small' = 'base';
 
   /**
    * Whether the datepicker is disabled
@@ -1415,6 +1420,7 @@ export class TkDatePicker {
         label={this.label}
         mode="text"
         icon="calendar_month"
+        size={this.labelSize}
         class={classNames('tk-datepicker-input', { 'tk-table-input': this.el.classList.contains('tk-table-datepicker') })}
         name={this.name}
         hint={this.hint}


### PR DESCRIPTION
Size prop added for label 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request adds a new size property to the tk-datepicker component's label, allowing customization with three options: 'large', 'base', and 'small', enhancing the control over its appearance.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>