### PR TITLE
feat(tk-table): Add different filtering logics

### DIFF
--- a/docs/src/docs-files/tk-table/Examples/FilterAndSort.tsx
+++ b/docs/src/docs-files/tk-table/Examples/FilterAndSort.tsx
@@ -8,6 +8,20 @@ const Example = () => {
     {
       field: 'id',
       header: 'Id',
+      searchable: true,
+      advancedFilters: [
+        {
+          name: 'startsWith',
+          filter: (value: string, rowValue: any) =>
+            rowValue?.toString().toLowerCase().startsWith(value) || false,
+        },
+        {
+          name: 'include',
+          filter: (value: string, rowValue: any) =>
+            rowValue?.toString().toLowerCase().includes(value.toLowerCase()) ||
+            false,
+        },
+      ],
     },
     {
       field: 'name',
@@ -21,6 +35,7 @@ const Example = () => {
           .toLowerCase()
           .indexOf(value.toString().toLowerCase() as string) > -1,
     },
+
     {
       field: 'status',
       header: 'Checkbox Filter',

--- a/packages/core/src/components/tk-table/helpers.ts
+++ b/packages/core/src/components/tk-table/helpers.ts
@@ -42,29 +42,7 @@ export const filterAndSort = (data: any[], columns: ITableColumn[], filters: ITa
         const fieldValue = getNestedValue(row, filter.field).toString();
         return fieldValue === filter.value;
       }
-
-      const filterableColumn = columns.find(col => col.field == filter.field);
-      if (filterableColumn?.advancedFilters) {
-        const select: HTMLTkSelectElement = document.querySelector('body > .tk-table-filter-panel > tk-select');
-        const filterType = select.value.value;
-        const fieldValue = getNestedValue(row, filter.field)?.toString();
-        switch (filterType) {
-          case 'startsWith':
-            return fieldValue.startsWith(filter.value);
-          case 'endsWith':
-            return fieldValue.endsWith(filter.value);
-          case 'contains':
-            return fieldValue.includes(filter.value);
-          case 'notContains':
-            return !fieldValue.includes(filter.value);
-          case 'equals':
-            return fieldValue === filter.value;
-          case 'notEquals':
-            return fieldValue !== filter.value;
-          default:
-            return true;
-        }
-      }
+      const filterableColumn = columns.find(col => col.field == filter.field && col.searchable && typeof col.filter == 'function');
       const result = filterableColumn?.filter(filter.value, row);
       if (result == undefined) return true;
       else return result;

--- a/packages/core/src/components/tk-table/helpers.ts
+++ b/packages/core/src/components/tk-table/helpers.ts
@@ -43,7 +43,24 @@ export const filterAndSort = (data: any[], columns: ITableColumn[], filters: ITa
         return fieldValue === filter.value;
       }
 
-      const filterableColumn = columns.find(col => col.field == filter.field && col.searchable && typeof col.filter == 'function');
+      const filterableColumn = columns.find(col => col.field == filter.field);
+      if (filterableColumn?.advancedFilters) {
+        const select: HTMLTkSelectElement = document.querySelector('body > .tk-table-filter-panel > tk-select');
+        const filterType = select.value.value;
+        const fieldValue = getNestedValue(row, filter.field)?.toString();
+        switch (filterType) {
+          case 'startsWith':
+            return fieldValue.startsWith(filter.value);
+          case 'endsWith':
+            return fieldValue.endsWith(filter.value);
+          case 'contains':
+            return fieldValue.includes(filter.value);
+          case 'notContains':
+            return !fieldValue.includes(filter.value);
+          default:
+            return true;
+        }
+      }
       const result = filterableColumn?.filter(filter.value, row);
       if (result == undefined) return true;
       else return result;

--- a/packages/core/src/components/tk-table/helpers.ts
+++ b/packages/core/src/components/tk-table/helpers.ts
@@ -57,6 +57,10 @@ export const filterAndSort = (data: any[], columns: ITableColumn[], filters: ITa
             return fieldValue.includes(filter.value);
           case 'notContains':
             return !fieldValue.includes(filter.value);
+          case 'equals':
+            return fieldValue === filter.value;
+          case 'notEquals':
+            return fieldValue !== filter.value;
           default:
             return true;
         }

--- a/packages/core/src/components/tk-table/interfaces.ts
+++ b/packages/core/src/components/tk-table/interfaces.ts
@@ -53,7 +53,7 @@ export interface ITableColumn {
 
 export interface IAdvanceFilter {
   name: string;
-  filter: Function;
+  filter: (value: string, rowValue: any) => boolean;
 }
 /**
  * Defines options for checkbox filter

--- a/packages/core/src/components/tk-table/interfaces.ts
+++ b/packages/core/src/components/tk-table/interfaces.ts
@@ -52,7 +52,7 @@ export interface ITableColumn {
 }
 
 export interface IAdvanceFilter {
-  label?: string;
+  name: string;
   filter: Function;
 }
 /**

--- a/packages/core/src/components/tk-table/interfaces.ts
+++ b/packages/core/src/components/tk-table/interfaces.ts
@@ -48,9 +48,13 @@ export interface ITableColumn {
     selectAllCheckbox?: { label?: string };
   };
   /** Defines the filtering types for the column */
-  advancedFilters?: boolean;
+  advancedFilters?: IAdvanceFilter[];
 }
 
+export interface IAdvanceFilter {
+  label?: string;
+  filter: Function;
+}
 /**
  * Defines options for checkbox filter
  */

--- a/packages/core/src/components/tk-table/interfaces.ts
+++ b/packages/core/src/components/tk-table/interfaces.ts
@@ -47,6 +47,8 @@ export interface ITableColumn {
     cancelButton?: { label?: string };
     selectAllCheckbox?: { label?: string };
   };
+  /** Defines the filtering types for the column */
+  advancedFilters?: boolean;
 }
 
 /**

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -531,7 +531,7 @@ export class TkTable implements ComponentInterface {
     // current page değiştiğinde pagination componenti 'handlePageChange' eventini tetiklediğinden 2 defa emit edilmesin diye buraya bu kontrol eklendi
     if (this.currentPage == 1) {
       const tmpData = filterAndSort(this.data, this.columns, this.filters, this.sortField, this.sortOrder);
-      this.generateRenderData(tmpData, 1);
+      this.generateRenderData(tmpData, 1, true);
     } else {
       this.currentPage = 1;
     }
@@ -748,6 +748,15 @@ export class TkTable implements ComponentInterface {
 
       this.elFilterPanelElement.appendChild(filterContainer);
     } else {
+      if (column.advancedFilters) {
+        const select: HTMLTkSelectElement = document.createElement('tk-select');
+        const filterOptions = ['startsWith', 'endsWith', 'contains', 'notContains'];
+        select.options = filterOptions.map(type => ({
+          label: type,
+          value: type,
+        }));
+        this.elFilterPanelElement.appendChild(select);
+      }
       // Default text input filter
       const input: HTMLTkInputElement = document.createElement('tk-input');
       input.placeholder = 'Search';

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -750,7 +750,7 @@ export class TkTable implements ComponentInterface {
     } else {
       if (column.advancedFilters) {
         const select: HTMLTkSelectElement = document.createElement('tk-select');
-        const filterOptions = ['startsWith', 'endsWith', 'contains', 'notContains'];
+        const filterOptions = ['startsWith', 'endsWith', 'contains', 'notContains', 'equals', 'notEquals'];
         select.options = filterOptions.map(type => ({
           label: type,
           value: type,

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -543,20 +543,16 @@ export class TkTable implements ComponentInterface {
     const searchInput: HTMLTkInputElement = document.querySelector('body > .tk-table-filter-panel > tk-input.advanced');
     const select: HTMLTkSelectElement = document.querySelector('body > .tk-table-filter-panel > tk-select.advanced');
     const column = this.columns.find(col => col.field === columnField);
-    const selectedFilter = column?.advancedFilters?.find(f => f.label.trim().toLowerCase() === select.value.value);
+    const selectedFilter = column?.advancedFilters?.find(f => f.name.trim().toLowerCase() === select.value.value);
 
     if (searchInput && selectedFilter) {
       const filteredData = this.data.filter(row => {
         const rowValue = getNestedValue(row, columnField);
-        return selectedFilter.filter(searchInput.value, rowValue);
+        return selectedFilter.filter(searchInput.value.toString().trim().toLowerCase(), rowValue);
       });
 
-      if (this.currentPage === 1) {
-        this.generateRenderData(filteredData, 1, true);
-      } else {
-        this.currentPage = 1;
-        this.generateRenderData(filteredData, 1, true);
-      }
+      this.currentPage = 1;
+      this.generateRenderData(filteredData, 1, true);
     }
 
     this.closeFilterPanel();
@@ -772,8 +768,8 @@ export class TkTable implements ComponentInterface {
       const select: HTMLTkSelectElement = document.createElement('tk-select');
       select.classList.add('advanced');
       select.options = column.advancedFilters.map(item => ({
-        label: item.label,
-        value: item.label.trim().toLowerCase(),
+        label: item.name,
+        value: item.name.trim().toLowerCase(),
       }));
       this.elFilterPanelElement.appendChild(select);
       const advancedInput: HTMLTkInputElement = document.createElement('tk-input');


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the tk-table component with advanced filtering options such as 'startsWith', 'endsWith', 'contains', 'notContains', 'equals', and 'notEquals', while also improving pagination logic for better performance. Additionally, documentation examples have been added to showcase the new functionalities, significantly boosting the component's flexibility and usability, and improving user experience.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>