### PR TITLE
fix(tk-table): Add condition for header

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -910,7 +910,7 @@ export class TkTable implements ComponentInterface {
             let _customHeaderElements: ICustomElement;
 
             // generate expander th
-            if (col.expander) {
+            if (!col.header && col.expander) {
               return <th></th>;
             }
 


### PR DESCRIPTION
Conditional rendering of expander column header now depends on whether col.header is defined. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the tk-table component by adjusting the conditional rendering of the expander column header, ensuring it only appears when the col.header property is defined. This enhancement improves usability by eliminating unnecessary header elements.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>