### PR TITLE
fix(tk-popover): Solve instancevalue issue

### DIFF
--- a/packages/core/src/components/tk-popover/tk-popover.tsx
+++ b/packages/core/src/components/tk-popover/tk-popover.tsx
@@ -72,7 +72,7 @@ export class TkPopover implements ComponentInterface {
       this.triggerElement?.addEventListener('mouseleave', () => (this.isOpen = false));
     } else {
       this.triggerElement?.addEventListener('click', () => (this.isOpen = !this.isOpen));
-      window.addEventListener('click', this.handleDocumentClick);
+      document.addEventListener('click', this.handleDocumentClick);
     }
   }
 
@@ -158,7 +158,7 @@ export class TkPopover implements ComponentInterface {
   }
 
   private handleDocumentClick = (e: MouseEvent) => {
-    const isInnerClicked = e.composedPath().some(item => item == this.el);
+    const isInnerClicked = e.composedPath().some(item => item === this.el);
     if (!isInnerClicked) {
       this.isOpen = false;
     }


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the tk-popover component by correcting the comparison operator in the instance value check and modifies the document click event listener for improved functionality, enhancing the popover's reliability in UI interactions.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>