### PR TITLE
feat(tk-table): Add stopPropagation to prevent rowclickevent when cel…

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -880,7 +880,16 @@ export class TkTable implements ComponentInterface {
     // Close the filter panel
     this.closeFilterPanel();
   }
+  private handleRowClick = (e: MouseEvent) => {
+    const path = e.composedPath();
+    const clickableElement = path.some(element => element instanceof HTMLElement && ['tk-popover', 'tk-dropdown'].includes(element.tagName.toLowerCase()));
 
+    if (clickableElement) {
+      e.stopPropagation();
+    } else {
+      this.tkRowClick.emit(e);
+    }
+  };
   private createHead() {
     this.customHeaderElements = [];
 
@@ -1042,7 +1051,7 @@ export class TkTable implements ComponentInterface {
 
             return (
               <Fragment>
-                <tr ref={el => (trElRef = el)} onClick={() => this.tkRowClick.emit(row)} aria-disabled={isRowDisabled}>
+                <tr ref={el => (trElRef = el)} onClick={this.handleRowClick} aria-disabled={isRowDisabled}>
                   {selectionTd}
                   {this.columns.map(col => {
                     let tdExpanderButtonRef!: HTMLTkButtonElement;


### PR DESCRIPTION
…l has a trigger element 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the tk-table component by introducing a new method, handleRowClick, to improve row click handling. It prevents event propagation for specific elements, thereby enhancing user interaction with the table.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on improving existing functionality, making the review process relatively simple.
-->
</div>