### PR TITLE
fix(tk-select): Solve custom filter method problem

### DIFF
--- a/packages/core/src/components/tk-select/tk-select.tsx
+++ b/packages/core/src/components/tk-select/tk-select.tsx
@@ -254,11 +254,15 @@ export class TkSelect implements ComponentInterface {
     this.handleFormReset();
   }
 
-  private async defaultFilter(text: string, options: any[]) {
-    if (!text) {
+  private async defaultFilter(text: any, options: any[]) {
+    if (typeof text !== 'string' || !text.trim()) {
       return [...this.options];
     }
-    return options.filter(item => this.getOptionLabel(item).toLowerCase().indexOf(text.toLowerCase()) > -1);
+
+    return options.filter(item => {
+      const label = this.getOptionLabel(item);
+      return typeof label === 'string' && label.toLowerCase().includes(text.toLowerCase());
+    });
   }
 
   private updatePosition() {
@@ -637,6 +641,10 @@ export class TkSelect implements ComponentInterface {
         onTk-change={e => {
           e.stopPropagation();
           this.handleInputChange(e.detail);
+        }}
+        onInput={(e: InputEvent) => {
+          const inputValue = (e.target as HTMLInputElement)?.value ?? '';
+          this.handleInputChange(inputValue); // native input için doğru trigger burada
         }}
         onTk-blur={() => setTimeout(() => this.handleInputBlur(), 100)}
         onTk-clear-click={() => this.handleInputClearClick()}


### PR DESCRIPTION
Fixes a bug where the custom filter function in <tk-select> threw a TypeError: text.toLowerCase is not a function during input. This occurred because the tk-change event from <tk-input> was emitting non-string values when used in editable mode. The issue is resolved by ensuring proper string value extraction from the native input, allowing custom filters to run as expected during typing.








 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a TypeError in the <tk-select> component by ensuring that the input value from <tk-input> is extracted as a string. This enhancement improves the filtering mechanism's robustness during user input.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on bug fixing, making the review process relatively simple.
-->
</div>