### PR TITLE
fix(tk-stepper): Implement isClickable prop to prevent step selection

### DIFF
--- a/packages/core/src/components/tk-stepper/tk-stepper.tsx
+++ b/packages/core/src/components/tk-stepper/tk-stepper.tsx
@@ -167,6 +167,7 @@ export class TkStepper implements ComponentInterface {
       error: step.error,
       isActive: index === this.internalActive,
       disabled: step.disabled || false,
+      isClickable: step.isClickable !== undefined ? step.isClickable : true,
     }));
   }
 
@@ -179,8 +180,11 @@ export class TkStepper implements ComponentInterface {
   }
 
   private canStepBeSelected(targetIndex: number): boolean {
-    if (!this.linear) return !this.steps[targetIndex]?.disabled;
-    if (targetIndex < this.internalActive) return !this.steps[targetIndex]?.disabled;
+    const targetStep = this.steps[targetIndex];
+    if (!targetStep || targetStep.disabled || !targetStep.isClickable) return false;
+
+    if (!this.linear) return true;
+    if (targetIndex < this.internalActive) return true;
     if (targetIndex === this.internalActive + 1) {
       const currentStep = this.steps[this.internalActive];
       return !currentStep?.error && !currentStep?.disabled;


### PR DESCRIPTION
- Add isClickable property initialization in initializeSteps method
- Update canStepBeSelected logic to respect isClickable property
- Ensure steps with isClickable=false cannot be selected or focused

Closes #88 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the tk-stepper component by adding an isClickable property, allowing for better control over selectable steps. The canStepBeSelected method has been updated to incorporate this property, improving user experience.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>