### PR TITLE
docs(tk-drawer): Remove footer from drawer demo

### DIFF
--- a/docs/src/docs-files/tk-drawer/Examples/Templating.tsx
+++ b/docs/src/docs-files/tk-drawer/Examples/Templating.tsx
@@ -178,9 +178,6 @@ const CustomContent = () => {
               <TkTabsItem label="Unreaded" badgeLabel="03" badged></TkTabsItem>
           </TkTabs>
       </div>
-      <div slot="footer">
-          <TkButton label="View All" variant="neutral" type="outlined"></TkButton>
-      </div>
   </TkDrawer>`;
 
   const vueCode = `<script setup>
@@ -270,9 +267,6 @@ const showDrawer = ref(false);
         <TkTabsItem label="Unreaded"></TkTabsItem>
       </TkTabs>
     </div>
-    <div slot="footer">
-      <TkButton label="View All" variant="neutral" type="outlined"></TkButton>
-    </div>
   </TkDrawer>
 </template>
 
@@ -361,13 +355,6 @@ ${demoStyles}
             <TkTabsItem label="New" badgeLabel="03" badged></TkTabsItem>
             <TkTabsItem label="Unreaded" badgeLabel="03" badged></TkTabsItem>
           </TkTabs>
-        </div>
-        <div slot="footer">
-          <TkButton
-            label="View All"
-            variant="neutral"
-            type="outlined"
-          ></TkButton>
         </div>
       </TkDrawer>
     </>


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the drawer demo by removing unnecessary footer elements, resulting in a more streamlined presentation. The changes improve usability and visual appeal, providing a cleaner example for users.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>