### PR TITLE
feat(tk-table): Adjust zIndex for filter panel

### DIFF
--- a/docs/src/docs-files/tk-table/api.mdx
+++ b/docs/src/docs-files/tk-table/api.mdx
@@ -110,6 +110,7 @@ interface ITableColumn {
     cancelButton?: { label?: string };
     selectAllCheckbox?: { label?: string };
     optionsSearchInput?: { show?: boolean; placeholder?: string };
+    emptyMessage?: string;
   };
 }
 ```

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -347,7 +347,7 @@ export class TkTable implements ComponentInterface {
       worksheet.columns = _columns
         .filter(item => !options.ignoreColumnsFields?.includes(item.field))
         .map(item => {
-          return { header: item.header, key: item.field, width: Number(item.width?.toString().replace('px', '')) / 7 || 20 };  //Add this 7 because of unit conversion (In excel inches are used and 7px is approximately 1inch)
+          return { header: item.header, key: item.field, width: Number(item.width?.toString().replace('px', '')) / 7 || 20 }; //Add this 7 because of unit conversion (In excel inches are used and 7px is approximately 1inch)
         });
 
       worksheet.addRows(
@@ -849,7 +849,7 @@ export class TkTable implements ComponentInterface {
     buttons.appendChild(cancelButton);
     buttons.appendChild(searchButton);
     this.elFilterPanelElement.appendChild(buttons);
-
+    this.elFilterPanelElement.style.zIndex = '1700';
     document.body.appendChild(this.elFilterPanelElement);
     this.isFilterOpen = true;
   }


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the tk-table component by improving the filter panel functionality, adding an 'emptyMessage' property to the API documentation, and adjusting the zIndex for better UI layering. Minor code formatting improvements have also been made for increased readability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>