### PR TITLE
feat(tk-input): Add getNestedValue method for dynamic label retrieval…

### DIFF
--- a/packages/core/src/components/tk-input/tk-input.tsx
+++ b/packages/core/src/components/tk-input/tk-input.tsx
@@ -274,6 +274,11 @@ export class TkInput implements ComponentInterface {
     if (/[^A-Za-z0-9]/.test(password)) strength++;
     return strength;
   }
+  private getNestedValue(obj, path) {
+    return path.split('.').reduce((acc, key) => {
+      return acc && acc[key] !== undefined ? acc[key] : undefined;
+    }, obj);
+  }
 
   private handleInput = (ev: Event) => {
     if (this.mode != 'chips') {
@@ -422,7 +427,7 @@ export class TkInput implements ComponentInterface {
           // multiple abject array selection için geliştirildi
           return (
             <tk-chips
-              label={item[this.chipLabelKey]}
+              label={this.getNestedValue(item, this.chipLabelKey)}
               removable
               onTk-remove={() => this.handleChipsRemove(item)}
               variant="neutral"


### PR DESCRIPTION
… in chips 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces the `getNestedValue` method in the `tk-input` component for dynamic retrieval of nested values in chip labels. It also updates label assignment in the chip component, enhancing flexibility for handling complex data structures.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>