### PR TITLE
fix(tk-toaster): Add max-width

### DIFF
--- a/packages/core/src/global/sass/components/_toaster.scss
+++ b/packages/core/src/global/sass/components/_toaster.scss
@@ -4,6 +4,7 @@
   flex-direction: column;
   gap: 16px;
   min-width: 360px;
+  max-width: 480px;
   z-index:2000;
 
   &.top-right {


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the toaster component by adding a max-width property of 480px, improving its responsiveness and layout. This change ensures a consistent appearance across various screen sizes, contributing to a better user experience for notifications.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>