### PR TITLE
refactor(tk-editor): Update active extensions logic

### DIFF
--- a/packages/core/src/components/tk-editor/defaults.ts
+++ b/packages/core/src/components/tk-editor/defaults.ts
@@ -1,35 +1,26 @@
-import { AnyExtension } from '@tiptap/core';
-import StarterKit from '@tiptap/starter-kit';
-import TextAlign from '@tiptap/extension-text-align';
-import Underline from '@tiptap/extension-underline';
-import Link from '@tiptap/extension-link';
-import Image from '@tiptap/extension-image';
 import { TkEditorToolbarConfig } from './interfaces';
-/**
- * Default Tiptap extensions with their configurations
- */
-export const DEFAULT_EXTENSIONS: AnyExtension[] = [
-  StarterKit.configure({}),
-  Underline.configure({}),
-  TextAlign.configure({
-    types: ['heading', 'paragraph'],
-    alignments: ['left', 'center', 'right', 'justify'],
-  }),
-  Link.configure({
-    openOnClick: true,
-    HTMLAttributes: {
-      class: 'tk-editor-link',
-    },
-  }),
-  Image.configure({
-    HTMLAttributes: {
-      class: 'tk-editor-image',
-    },
-  }),
-];
-/**
- * Default toolbar configuration with all available buttons
- */
+
+export const STARTER_KIT_EXTENSION_NAMES = [
+  'blockquote',
+  'bold',
+  'bulletList',
+  'code',
+  'codeBlock',
+  'document',
+  'dropcursor',
+  'gapcursor',
+  'hardBreak',
+  'heading',
+  'history',
+  'horizontalRule',
+  'italic',
+  'listItem',
+  'orderedList',
+  'paragraph',
+  'strike',
+  'text',
+] as const;
+
 export const DEFAULT_TOOLBAR_CONFIG: TkEditorToolbarConfig = [
   // Heading buttons
   ['h1', 'h2', 'h3', 'h4'],


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request refactors the logic for managing active extensions in the tk-editor component, enhancing the default extensions configuration and improving user-defined extensions handling. The changes streamline the integration of text editing features for a more efficient editor setup.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>