### PR TITLE
feat(tk-upload): Add showFiles prop to control file display

### DIFF
--- a/packages/core/src/components/tk-upload/tk-upload.tsx
+++ b/packages/core/src/components/tk-upload/tk-upload.tsx
@@ -48,6 +48,12 @@ export class TkUpload implements ComponentInterface {
   @Prop() showAsterisk: boolean = false;
 
   /**
+   * Displays the uploaded files.
+   * @defaultValue true
+   */
+  @Prop() showFiles: boolean = true;
+
+  /**
    * Label text displayed inside the choose button.
    */
   @Prop() chooseButtonLabel: string = 'Choose File';
@@ -372,7 +378,7 @@ export class TkUpload implements ComponentInterface {
         {label}
         {this.renderDropzone()}
         {hint}
-        {this.renderFileholder()}
+        {this.showFiles && this.renderFileholder()}
       </div>
     );
   }


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the tk-upload component by introducing a 'showFiles' prop, allowing users to control the visibility of uploaded files. The rendering logic has been updated to conditionally display the file holder based on this new prop, improving component flexibility.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve the addition of a new prop and related rendering logic, making the review process relatively simple.
-->
</div>