### PR TITLE
fix(tk-table): Fix loading when there is custom cell

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.scss
+++ b/packages/core/src/components/tk-table/tk-table.scss
@@ -262,7 +262,7 @@
 
       .tk-table-sticky-shadow-right {
         --shadow-opacity: 0;
-        
+
         &::after {
           content: '';
           position: absolute;
@@ -270,11 +270,7 @@
           right: -10px;
           bottom: 0;
           width: 10px;
-          background: linear-gradient(to right, 
-            rgba(0, 0, 0, 0.12) 0%, 
-            rgba(0, 0, 0, 0.06) 30%, 
-            rgba(0, 0, 0, 0.02) 70%,
-            transparent 100%);
+          background: linear-gradient(to right, rgba(0, 0, 0, 0.12) 0%, rgba(0, 0, 0, 0.06) 30%, rgba(0, 0, 0, 0.02) 70%, transparent 100%);
           pointer-events: none;
           opacity: var(--shadow-opacity, 0);
           transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -284,7 +280,7 @@
 
       .tk-table-sticky-shadow-left {
         --shadow-opacity: 0;
-        
+
         &::before {
           content: '';
           position: absolute;
@@ -292,11 +288,7 @@
           left: -10px;
           bottom: 0;
           width: 10px;
-          background: linear-gradient(to left, 
-            rgba(0, 0, 0, 0.12) 0%, 
-            rgba(0, 0, 0, 0.06) 30%, 
-            rgba(0, 0, 0, 0.02) 70%,
-            transparent 100%);
+          background: linear-gradient(to left, rgba(0, 0, 0, 0.12) 0%, rgba(0, 0, 0, 0.06) 30%, rgba(0, 0, 0, 0.02) 70%, transparent 100%);
           pointer-events: none;
           opacity: var(--shadow-opacity, 0);
           transition: opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -344,7 +336,6 @@
     display: flex;
     justify-content: center;
     position: absolute;
-    top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
 

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -242,9 +242,13 @@ export class TkTable implements ComponentInterface {
   }
 
   componentDidRender(): void {
-    this.customCellElements?.forEach(element => {
-      element?.ref?.replaceChildren(element.element);
-    });
+    if (!this.loading) {
+      this.customCellElements?.forEach(element => {
+        element?.ref?.replaceChildren(element.element);
+      });
+    } else {
+      this.clearCustomElements();
+    }
 
     this.customHeaderElements?.forEach(element => {
       element?.ref?.replaceChildren(element.element);
@@ -252,7 +256,7 @@ export class TkTable implements ComponentInterface {
   }
 
   componentWillUpdate(): Promise<void> | void {
-    // ampty-data slot'unun data her değiştiğinde görünürlüğünü ayarlamak için yapılmıştır.
+    // empty-data slot'unun data her değiştiğinde görünürlüğünü ayarlamak için yapılmıştır.
     const slotEmptyData: HTMLElement = this.el.querySelector("[slot='empty-data']");
 
     if (slotEmptyData) {
@@ -506,6 +510,13 @@ export class TkTable implements ComponentInterface {
     this.expandedRows = newExpandedRows;
 
     this.tkExpandedRowsChange.emit(this.expandedRows);
+  }
+
+  private clearCustomElements() {
+    this.customCellElements?.forEach(element => {
+      element?.element?.remove();
+    });
+    this.customCellElements = [];
   }
 
   private updatePosition() {
@@ -1379,11 +1390,7 @@ export class TkTable implements ComponentInterface {
   }
 
   private createBody() {
-    // clear custom cell elements
-    this.customCellElements?.forEach(element => {
-      element?.element?.remove();
-    });
-    this.customCellElements = [];
+    this.clearCustomElements();
 
     if (this.renderData?.length > 0) {
       return (


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the tk-table component related to loading custom cell elements, ensuring proper rendering based on the loading state. It also improves the visual appearance of sticky shadows by updating the associated styles.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on bug fixes and style enhancements, making the review process relatively simple.
-->
</div>