### PR TITLE
Figma access link was added to the documentation website.

### DIFF
--- a/docs/docs/Figma.mdx
+++ b/docs/docs/Figma.mdx
@@ -7,8 +7,7 @@ import { useEffect } from 'react';
 
 export const FigmaRedirect = () => {
   useEffect(() => {
-    window.open('https://www.figma.com/design/4fjXE80dA5O1ZehTlHx7aE/Take-Off-Design-System?node-id=1-2&t=9ss3NxC6c0mApqgm-1', '_blank');
-    window.history.back();
+  window.open('https://www.figma.com/design/4fjXE80dA5O1ZehTlHx7aE/Take-Off-Design-System?node-id=1-2&t=9ss3NxC6c0mApqgm-1', '_blank', 'noopener,noreferrer');
   }, []);
   return <div>Redirecting to Figma...</div>;
 };

--- a/docs/docs/Introduction.mdx
+++ b/docs/docs/Introduction.mdx
@@ -3,6 +3,8 @@ sidebar_position: 1
 title: Introduction
 ---
 
+import { TkButton } from '@takeoff-ui/react';
+
 # Takeoff UI Design System
 
 Takeoff UI is a comprehensive design system providing framework-agnostic web components developed with [Stencil.js](https://stenciljs.com/). The system is managed as a monorepo using [Turborepo](https://turbo.build/), enabling fast, incremental builds and consistent workflows across multiple packages.
@@ -10,7 +12,17 @@ Takeoff UI is a comprehensive design system providing framework-agnostic web com
 ## Figma Design System
 
 The Takeoff UI Figma Design System provides a set of design assets, including components, styles, and guidelines to help designers and developers create consistent user interfaces. The Figma library is organized into categories, making it easy to find and use the right components.
-- You can access the Figma Design System [here](https://www.figma.com/design/4fjXE80dA5O1ZehTlHx7aE/Take-Off-Design-System?node-id=1-2&t=9ss3NxC6c0mApqgm-1).
+
+<TkButton 
+  label="Reach Figma" 
+  type="outlined" 
+  variant="neutral" 
+  icon="arrow_outward" 
+  iconPosition="right" 
+  onTkClick={() => {
+      window.open('https://www.figma.com/design/4fjXE80dA5O1ZehTlHx7aE/Take-Off-Design-System?node-id=1-2&t=9ss3NxC6c0mApqgm-1', '_blank', 'noopener,noreferrer');
+  }}
+/>
 
 ## Technical Architecture
 


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances documentation by adding a section on the Figma Design System, including a new button for design asset access and a redirect component for improved security with 'noopener,noreferrer'. This aims to boost accessibility and understanding for designers and developers.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>