### PR TITLE
XSmall size option was added to the table component.

### DIFF
--- a/docs/src/docs-files/tk-table/Examples/Size.tsx
+++ b/docs/src/docs-files/tk-table/Examples/Size.tsx
@@ -30,6 +30,7 @@ const Example = () => {
     <div className="p-2">
       <div style={{ overflow: 'overlay' }} className="mb-4">
         <TkRadioGroup value={size} onTkChange={e => setSize(e.detail)}>
+          <TkRadio label="XSmall" value="xsmall" />
           <TkRadio label="Small" value="small" />
           <TkRadio label="Base" value="base" />
         </TkRadioGroup>

--- a/docs/src/docs-files/tk-table/api.mdx
+++ b/docs/src/docs-files/tk-table/api.mdx
@@ -21,7 +21,7 @@ import { TkBadge } from "@takeoff-ui/react";
 | <TkBadge label="selection" variant="primary" size="large" type="filledlight"/> | <code>any</code> | [] | List of the selected |
 | <TkBadge label="selectionMode" variant="primary" size="large" type="filledlight"/> | <code>"checkbox", "radio"</code> | null | Determines how rows can be selected, either with radio buttons (single selection) or checkboxes (multiple selection). |
 | <TkBadge label="selectionRowDisabled" variant="primary" size="large" type="filledlight"/> | <code>Function</code> | null | A function that returns true if the row should be disabled |
-| <TkBadge label="size" variant="primary" size="large" type="filledlight"/> | <code>"base", "small"</code> | 'base' | Sets size for the component. |
+| <TkBadge label="size" variant="primary" size="large" type="filledlight"/> | <code>"base", "small", "xsmall"</code> | 'base' | Sets size for the component. |
 | <TkBadge label="striped" variant="primary" size="large" type="filledlight"/> | <code>boolean</code> | false | Enables or disables alternating row background colors for easier readability. |
 | <TkBadge label="totalItems" variant="primary" size="large" type="filledlight"/> | <code>number</code> | null | Number of total items. |
 

--- a/packages/core/src/components/tk-table/tk-table.scss
+++ b/packages/core/src/components/tk-table/tk-table.scss
@@ -190,7 +190,7 @@
             font-weight: 400;
             line-height: 20px;
             background-color: var(--static-light);
-            padding: var(--table-items-body-base-text-v-padding) 12px var(--table-items-body-base-text-v-padding) 16px;
+            padding: var(--table-items-body-base-text-v-padding) var(--table-items-head-small-text-h-padding);
             border: none;
             border-bottom: 1px solid var(--border-light);
             vertical-align: middle;
@@ -301,14 +301,30 @@
 
   &.small {
     table thead tr th {
-      padding: var(--table-items-head-small-text-v-padding) var(--table-items-head-small-text-h-padding);
+      padding: var(--table-items-head-small-text-v-padding);
     }
 
     table tbody tr td {
-      padding: var(--table-items-body-small-text-v-padding) 12px var(--table-items-body-small-text-v-padding) var(--table-items-body-small-text-h-padding);
+      padding: var(--table-items-body-small-text-v-padding);
 
       &.non-text {
         padding: var(--table-items-body-small-nontext-v-padding) var(--table-items-body-small-nontext-h-padding);
+      }
+    }
+  }
+
+  &.xsmall {
+    table thead tr th {
+      padding: var(--table-items-head-xsmall-text-v-padding) var(--table-items-head-xsmall-text-h-padding);
+      font-size: var(--desktop-body-xs-size);
+    }
+
+    table tbody tr td {
+      padding: var(--table-items-body-xsmall-text-v-padding) var(--table-items-body-xsmall-text-h-padding);
+      font-size: var(--desktop-body-xs-size);
+
+      &.non-text {
+        padding: var(--table-items-body-xsmall-text-v-padding) var(--table-items-body-xsmall-text-h-padding);
       }
     }
   }

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -82,7 +82,7 @@ export class TkTable implements ComponentInterface {
   /**
    * Sets size for the component.
    */
-  @Prop() size: 'small' | 'base' = 'base';
+  @Prop() size: 'xsmall' | 'small' | 'base' = 'base';
 
   /**
    * Property of each row that defines the unique key of each row

--- a/packages/core/src/global/sass/abstracts/_variables.scss
+++ b/packages/core/src/global/sass/abstracts/_variables.scss
@@ -1155,6 +1155,10 @@
   --table-items-head-small-text-text-gap: var(--spacing-m-base);
   --table-items-head-small-text-v-padding: var(--spacing-m-base);
   --table-items-head-small-text-gap: var(--spacing-m-base);
+  --table-items-head-xsmall-text-h-padding: var(--spacing-xs);
+  --table-items-head-xsmall-text-v-padding: var(--spacing-xs);
+  --table-items-body-xsmall-text-v-padding: var(--spacing-xs);
+  --table-items-body-xsmall-text-h-padding: var(--spacing-xs);
 
   // tabs variables
   --tabs-items-large-h-padding: var(--spacing-4xl);


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds a new 'xsmall' size option for the tk-table component, enhancing its flexibility. The API documentation has been updated to reflect this change, and example usage has been modified. Additionally, padding adjustments have improved the overall layout of the table elements.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>