### PR TITLE
refactor(docs): Rename 'Drag and Drop Sorting' section to 'Column Arr…

### DIFF
--- a/docs/src/docs-files/tk-table/Examples/DragAndDropSorting.tsx
+++ b/docs/src/docs-files/tk-table/Examples/DragAndDropSorting.tsx
@@ -63,7 +63,7 @@ const Example = () => {
     <div className="flex flex-col gap-2">
       <TkPopover className="flex justify-end" position="bottom" trigger="click">
         <TkButton variant="neutral" type="outlined" slot="trigger" label="Arrange Columns" />
-        <div slot="content" className="p-2">
+        <div slot="content">
           <div className="flex flex-col gap-2">
             {columns.map((col, index) => (
               <div key={col.field} className="flex justify-between gap-2 py-2 px-3 hover:bg-gray-100 transition-colors">
@@ -165,7 +165,7 @@ const dragAndDropSorting = () => {
           slot="trigger"
           label="Arrange Columns"
         />
-        <div slot="content" className="p-2">
+        <div slot="content">
           <div className="flex flex-col gap-2">
             {columns.map((col, index) => (
               <div
@@ -289,7 +289,7 @@ const handleCheckboxChange = (e: any, col: ITableColumn) => {
         slot="trigger"
         label="Arrange Columns"
       />
-      <div slot="content" style="padding: 8px">
+      <div slot="content">
         <div
           style="display: flex; flex-direction: column; gap: 8px; padding: 8px"
         >

--- a/docs/src/docs-files/tk-table/body.mdx
+++ b/docs/src/docs-files/tk-table/body.mdx
@@ -131,7 +131,7 @@ This feature allows the selected columns stay in their position in case of havin
 
 <StickyColumn />
 
-## Drag and Drop Sorting
+## Column Arrangement
 
 This feature allows the user to drag and drop the columns to the desired position.
 


### PR DESCRIPTION
…angement' 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the documentation and structure of the Drag and Drop Sorting feature by renaming the section to 'Column Arrangement' for better clarity and removing unnecessary padding from content slots, improving the layout.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>