### PR TITLE
The z-index issue with using a popover in a custom cell of the table component has been resolved.

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -1259,7 +1259,7 @@ export class TkTable implements ComponentInterface {
     return classes.join(' ');
   }
 
-  private getStickyColumnStyle(col: ITableColumn) {
+  private getStickyColumnStyle(col: ITableColumn, rowIndex?: number) {
     const style: any = {
       width: this.columnWidths[col.field] || col.width,
       minWidth: this.columnWidths[col.field] || col.width,
@@ -1272,8 +1272,9 @@ export class TkTable implements ComponentInterface {
 
       style['--tk-table-sticky-left-offset'] = `${this.stickyOffsets.left[col.field]}px`;
       style['left'] = `${this.stickyOffsets.left[col.field]}px`;
+      // Z-index: hem columnIndex hem rowIndex'e göre azalt
       // En soldaki kolon en yüksek z-index'e sahip olmalı (en üstte durmalı)
-      style['zIndex'] = 30 - columnIndex; // Left sticky: 30, 29, 28... (soldan sağa azalıyor)
+      style['zIndex'] = Math.max(99 - columnIndex - (rowIndex ?? 0), 0);
     } else if (col.fixed === 'right' && this.stickyOffsets.right[col.field] !== undefined) {
       style['--tk-table-sticky-right-offset'] = `${this.stickyOffsets.right[col.field]}px`;
       style['right'] = `${this.stickyOffsets.right[col.field]}px`;
@@ -1285,8 +1286,8 @@ export class TkTable implements ComponentInterface {
       // offset=0 (en sağdaki) -> z-index=30
       // offset arttıkça z-index azalır
       const offsetLevel = Math.floor(rightOffset / 50); // Her 50px'te bir level
-      const zIndex = 30 - offsetLevel;
-      style['zIndex'] = Math.max(zIndex, 20); // Minimum z-index 20
+      const zIndex = 99 - offsetLevel;
+      style['zIndex'] = Math.max(zIndex - (rowIndex ?? 0), 0); // Satır aşağı indikçe z-index azalır
     }
 
     return style;
@@ -1514,7 +1515,7 @@ export class TkTable implements ComponentInterface {
                       return (
                         <td
                           class={classNames(this.getStickyColumnClasses(col, isFirstLeft, isLastRight))}
-                          style={{ ...this.getStickyColumnStyle(col), ...styleRowObject, ...styleCellObject }}
+                          style={{ ...this.getStickyColumnStyle(col, index), ...styleRowObject, ...styleCellObject }}
                         >
                           <tk-button
                             ref={el => (tdExpanderButtonRef = el)}
@@ -1536,7 +1537,7 @@ export class TkTable implements ComponentInterface {
                             class={classNames('non-text', this.getStickyColumnClasses(col, isFirstLeft, isLastRight))}
                             innerHTML={cellElement}
                             style={{
-                              ...this.getStickyColumnStyle(col),
+                              ...this.getStickyColumnStyle(col, index),
                               ...styleRowObject,
                               ...styleCellObject,
                             }}
@@ -1548,7 +1549,7 @@ export class TkTable implements ComponentInterface {
                             ref={el => this.customCellElements.push({ ref: el as HTMLElement, element: cellElement })}
                             class={classNames('non-text', this.getStickyColumnClasses(col, isFirstLeft, isLastRight))}
                             style={{
-                              ...this.getStickyColumnStyle(col),
+                              ...this.getStickyColumnStyle(col, index),
                               ...styleRowObject,
                               ...styleCellObject,
                             }}
@@ -1561,7 +1562,7 @@ export class TkTable implements ComponentInterface {
                         <td
                           class={classNames('non-text editable', this.getStickyColumnClasses(col, isFirstLeft, isLastRight))}
                           style={{
-                            ...this.getStickyColumnStyle(col),
+                            ...this.getStickyColumnStyle(col, index),
                             ...styleRowObject,
                             ...styleCellObject,
                           }}
@@ -1580,7 +1581,7 @@ export class TkTable implements ComponentInterface {
                         <td
                           class={classNames(this.getStickyColumnClasses(col, isFirstLeft, isLastRight))}
                           style={{
-                            ...this.getStickyColumnStyle(col),
+                            ...this.getStickyColumnStyle(col, index),
                             ...styleRowObject,
                             ...styleCellObject,
                           }}


### PR DESCRIPTION
…dex calculation 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the sticky column styling in the tk-table component by adjusting the z-index calculation based on the row index. This modification prevents overlapping issues and improves the visual hierarchy when multiple sticky columns are present.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on styling adjustments, making the review process relatively simple.
-->
</div>