### PR TITLE
The readonly state behavior in select has been fixed.

### DIFF
--- a/docs/src/components/ReleaseNavigate/ReleaseNavigate.tsx
+++ b/docs/src/components/ReleaseNavigate/ReleaseNavigate.tsx
@@ -6,7 +6,7 @@ export default function ReleaseNavigate() {
       <h1>Version 0.1.0 and later release notes are available on GitHub!</h1>
       <a href="https://github.com/turkishtechnology/takeoff-ui/releases" target="_blank" rel="noopener noreferrer">
         <TkButton
-          label="View on GitHub"
+          label="View Release Note"
           variant="primary"
           size="large"
           style={{

--- a/packages/core/src/components/tk-select/tk-select.tsx
+++ b/packages/core/src/components/tk-select/tk-select.tsx
@@ -249,6 +249,12 @@ export class TkSelect implements ComponentInterface {
   componentDidRender(): void {
     // multiple durumda chips li input çalıştığı için ve tk-input value olarak chips leri geri döndürdüğü için
     // tk-input'un içindeki inputa yazılan değerlerin filtering için çalışabilmesini sağlamak için yapılmıştır.
+    if (this.readonly) {
+      const nativeInput = this.inputRef?.querySelector('input');
+      if (nativeInput) {
+        nativeInput.setAttribute('readonly', 'true');
+      }
+    }
     if (this.multiple && this.editable) {
       this.nativeInputRef?.removeEventListener('input', this.boundRunFilterForMultiple);
       this.nativeInputRef?.addEventListener('input', this.boundRunFilterForMultiple);
@@ -510,6 +516,7 @@ export class TkSelect implements ComponentInterface {
   }
 
   private async handleSelectAllClick() {
+    if (this.readonly) return;
     this.isItemClickFlag = true;
     if (this.multiple) {
       let tmpValue;
@@ -540,6 +547,7 @@ export class TkSelect implements ComponentInterface {
   }
 
   private async handleItemClick(item) {
+    if (this.readonly) return;
     this.isItemClickFlag = true;
     if (this.multiple) {
       let tmpValue = Array.isArray(this.value) ? [...this.value] : [];


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the readonly functionality of the tk-select component by adding checks to prevent user interactions when in readonly mode. It ensures input fields are set to readonly and bypasses item selection actions, improving usability in readonly scenarios.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on enhancing existing functionality, making the review process relatively simple.
-->
</div>