### PR TITLE
 Enhance sorting appearance with badge indicators for multi-sort 

### DIFF
--- a/docs/src/components/ReleaseNavigate/ReleaseNavigate.tsx
+++ b/docs/src/components/ReleaseNavigate/ReleaseNavigate.tsx
@@ -6,7 +6,7 @@ export default function ReleaseNavigate() {
       <h1>Version 0.1.0 and later release notes are available on GitHub!</h1>
       <a href="https://github.com/turkishtechnology/takeoff-ui/releases" target="_blank" rel="noopener noreferrer">
         <TkButton
-          label="View on GitHub"
+          label="View Release Note"
           variant="primary"
           size="large"
           style={{

--- a/packages/core/src/components/tk-table/helpers.ts
+++ b/packages/core/src/components/tk-table/helpers.ts
@@ -136,9 +136,15 @@ export const filterAndSort = (data: any[], columns: ITableColumn[], filters: ITa
       });
     }
   }
-  // #endregion
+  if (sorts && sorts.length > 0) {
+    return {
+      data: sortAndFilterData,
+      sorts: sorts.map((s, i) => ({ ...s, index: i + 1 })),
+    };
+  }
   return sortAndFilterData;
 };
+// #endregion
 
 export const getNestedValue = (row, path) => {
   return path.split('.').reduce((acc, key) => {

--- a/packages/core/src/components/tk-table/helpers.ts
+++ b/packages/core/src/components/tk-table/helpers.ts
@@ -136,12 +136,6 @@ export const filterAndSort = (data: any[], columns: ITableColumn[], filters: ITa
       });
     }
   }
-  if (sorts && sorts.length > 0) {
-    return {
-      data: sortAndFilterData,
-      sorts: sorts.map((s, i) => ({ ...s, index: i + 1 })),
-    };
-  }
   return sortAndFilterData;
 };
 // #endregion

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -723,19 +723,14 @@ export class TkTable implements ComponentInterface {
 
       if (icon === 'arrow_drop_up') {
         currentSort.order = 'desc';
-        refSortIcon.icon = 'arrow_drop_down';
       } else if (icon === 'arrow_drop_down') {
         this.sorts.splice(existingIndex, 1);
-        this.el.shadowRoot.querySelector(`thead th[data-field="${col.field}"] tk-badge`)?.remove();
-        refSortIcon.icon = 'swap_vert';
       }
     } else {
       this.sorts.push({
         field: col.field,
         order: 'asc',
       });
-
-      refSortIcon.icon = 'arrow_drop_up';
     }
 
     this.applySorting();
@@ -744,25 +739,7 @@ export class TkTable implements ComponentInterface {
   private applySorting() {
     if (this.currentPage === 1) {
       const tmpData = filterAndSort(this.data, this.columns, this.filters, this.sortField, this.sortOrder, this.sorts);
-      if (this.multiSort && tmpData.sorts) {
-        this.el.shadowRoot.querySelectorAll('thead th tk-badge').forEach(badge => badge.remove());
-        for (const sort of tmpData.sorts) {
-          const thElement = this.el.shadowRoot.querySelector(`thead th[data-field="${sort.field}"] .tk-table-head-cell .icons`);
-          if (thElement) {
-            const badge = document.createElement('tk-badge');
-            badge.count = sort.index;
-            badge.type = 'filledlight';
-            badge.rounded = true;
-            badge.variant = 'info';
-            badge.size = 'small';
-
-            thElement.appendChild(badge);
-          }
-        }
-        this.generateRenderData(tmpData.data, 1);
-      } else {
-        this.generateRenderData(tmpData, 1);
-      }
+      this.generateRenderData(tmpData, 1);
     } else {
       this.currentPage = 1;
     }
@@ -1397,7 +1374,24 @@ export class TkTable implements ComponentInterface {
 
             // generate head sort and search icons
 
-            _sortIcon = col.sortable && (
+            // generate head sort and search icons
+            const sortIndex = this.sorts.findIndex(s => s.field === col.field);
+            const sortObj = this.sorts.find(s => s.field === col.field);
+            const iconType = sortObj ? (sortObj.order === 'asc' ? 'arrow_drop_up' : sortObj.order === 'desc' ? 'arrow_drop_down' : 'swap_vert') : 'swap_vert';
+
+            const showBadge = sortIndex > -1 && this.sorts.length > 0 && this.multiSort;
+            _sortIcon = showBadge ? (
+              <tk-badge count={sortIndex + 1} type="text" rounded size="small">
+                <tk-icon
+                  {...getIconElementProps(iconType, {
+                    class: classNames('sort-icon'),
+                    variant: null,
+                    ref: (el: any) => (refSortIcon = el),
+                    onClick: () => this.renderData?.length > 0 && this.handleSortIconClick(refSortIcon, col),
+                  })}
+                />
+              </tk-badge>
+            ) : (
               <tk-icon
                 {...getIconElementProps('swap_vert', {
                   class: classNames('sort-icon'),
@@ -1447,7 +1441,7 @@ export class TkTable implements ComponentInterface {
                   {_headerStructure}
                   {(col.sortable || col.searchable) && (
                     <div class={classNames('icons', { 'show-icon-on-hover': col.showIconsOnHover && !this.elFilterPanelElement }, buttonDirection)}>
-                      {_sortIcon}
+                      {col.sortable && _sortIcon}
                       {_searchIcon}
                     </div>
                   )}

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -726,6 +726,7 @@ export class TkTable implements ComponentInterface {
         refSortIcon.icon = 'arrow_drop_down';
       } else if (icon === 'arrow_drop_down') {
         this.sorts.splice(existingIndex, 1);
+        this.el.shadowRoot.querySelector(`thead th[data-field="${col.field}"] tk-badge`)?.remove();
         refSortIcon.icon = 'swap_vert';
       }
     } else {
@@ -743,7 +744,25 @@ export class TkTable implements ComponentInterface {
   private applySorting() {
     if (this.currentPage === 1) {
       const tmpData = filterAndSort(this.data, this.columns, this.filters, this.sortField, this.sortOrder, this.sorts);
-      this.generateRenderData(tmpData, 1);
+      if (this.multiSort && tmpData.sorts) {
+        this.el.shadowRoot.querySelectorAll('thead th tk-badge').forEach(badge => badge.remove());
+        for (const sort of tmpData.sorts) {
+          const thElement = this.el.shadowRoot.querySelector(`thead th[data-field="${sort.field}"] .tk-table-head-cell .icons`);
+          if (thElement) {
+            const badge = document.createElement('tk-badge');
+            badge.count = sort.index;
+            badge.type = 'filledlight';
+            badge.rounded = true;
+            badge.variant = 'info';
+            badge.size = 'small';
+
+            thElement.appendChild(badge);
+          }
+        }
+        this.generateRenderData(tmpData.data, 1);
+      } else {
+        this.generateRenderData(tmpData, 1);
+      }
     } else {
       this.currentPage = 1;
     }
@@ -1422,6 +1441,7 @@ export class TkTable implements ComponentInterface {
                   ...this.getStickyColumnStyle(col),
                   ...col?.style,
                 }}
+                data-field={col.field}
               >
                 <div class="tk-table-head-cell">
                   {_headerStructure}


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the multi-sort functionality of the tk-table component by improving the sorting logic and visually representing the sort order with badges. The updates aim to enhance user experience by making table data sorting more intuitive and visually informative.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>