### PR TITLE
Improve window click handling to only include select panel and input on select component

### DIFF
--- a/docs/src/components/ReleaseNavigate/ReleaseNavigate.tsx
+++ b/docs/src/components/ReleaseNavigate/ReleaseNavigate.tsx
@@ -6,7 +6,7 @@ export default function ReleaseNavigate() {
       <h1>Version 0.1.0 and later release notes are available on GitHub!</h1>
       <a href="https://github.com/turkishtechnology/takeoff-ui/releases" target="_blank" rel="noopener noreferrer">
         <TkButton
-          label="View on GitHub"
+          label="View Release Note"
           variant="primary"
           size="large"
           style={{

--- a/packages/core/src/components/tk-select/tk-select.tsx
+++ b/packages/core/src/components/tk-select/tk-select.tsx
@@ -508,7 +508,10 @@ export class TkSelect implements ComponentInterface {
   }
 
   private handleWindowClick(event: MouseEvent) {
-    const isInnerClicked = event.composedPath().some(item => item == this.el);
+    const tkInputEl = this.el.querySelector('.tk-input');
+    const tkSelectPanelEl = this.el.querySelector('.tk-select-panel');
+    const isInnerClicked = event.composedPath().some(item => item === tkInputEl || item === tkSelectPanelEl);
+
     if (!isInnerClicked) {
       this.isOpen = false;
       this.unbindWindowClickListener();


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the click handling functionality of the tk-select component by refining the logic for recognizing click events. It ensures that clicks on both the input and select panel are properly detected, improving user interaction and providing a more intuitive experience.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on improving existing functionality, making the review process relatively simple.
-->
</div>