### PR TITLE
Added sticky header feature to table component.

### DIFF
--- a/docs/src/docs-files/tk-table/Examples/StickyHeader.tsx
+++ b/docs/src/docs-files/tk-table/Examples/StickyHeader.tsx
@@ -1,0 +1,118 @@
+import { ITableColumn } from '@takeoff-ui/core';
+import { TkTable } from '@takeoff-ui/react';
+import FeatureDemo from '../../../components/FeatureDemo';
+import React from 'react';
+import { stickyData } from './data';
+
+const Example = () => {
+  const column: ITableColumn[] = [
+    {
+      field: 'id',
+      header: 'Id',
+    },
+    {
+      field: 'name',
+      header: 'Name',
+    },
+    {
+      field: 'category',
+      header: 'Category',
+    },
+    {
+      field: 'quantity',
+      header: 'Quantity',
+    },
+    {
+      field: 'place',
+      header: 'Place',
+    },
+    {
+      field: 'status',
+      header: 'Status',
+    },
+  ];
+  return (
+    <div className="p-2">
+      <TkTable columns={column} data={stickyData} containerStyle={{ height: '300px' }}></TkTable>
+    </div>
+  );
+};
+
+const StickyHeader = () => {
+  const reactCode = `const tableRef = useRef<HTMLTkTableElement>(null);
+
+const column: ITableColumn[] = [
+  {
+      field: "id",
+      header: "Id",
+    },
+    {
+      field: "name",
+      header: "Name",
+    },
+    {
+      field: "category",
+      header: "Category",
+    },
+    {
+      field: "quantity",
+      header: "Quantity",
+    },
+    {
+      field: "place",
+      header: "Place",
+    },
+    {
+      field: "status",
+      header: "Status",
+    },
+];
+return (
+    <TkTable columns={column} data={stickyData} containerStyle={{height: "300px"}}>
+    </TkTable>
+);`;
+
+  const vueCode = `<script setup>
+import { TkTable } from '@takeoff-ui/vue'
+
+const column = [
+    {
+      field: "id",
+      header: "Id",
+    },
+    {
+      field: "name",
+      header: "Name",
+    },
+    {
+      field: "category",
+      header: "Category",
+    },
+    {
+      field: "quantity",
+      header: "Quantity",
+    },
+    {
+      field: "place",
+      header: "Place",
+    },
+    {
+      field: "status",
+      header: "Status",
+      fixed: "right",
+    },
+  ];
+</script>
+
+<template>
+    <TkTable :columns.prop="column" :data.prop="stickyData" :containerStyle="{height: "300px"}">
+    </TkTable>
+</template>
+`;
+
+  const demo = <Example />;
+
+  return <FeatureDemo demo={demo} reactCode={reactCode} vueCode={vueCode} angularCode={''}></FeatureDemo>;
+};
+
+export default StickyHeader;

--- a/docs/src/docs-files/tk-table/body.mdx
+++ b/docs/src/docs-files/tk-table/body.mdx
@@ -10,6 +10,7 @@ import RowCellStyle from './Examples/RowCellStyle';
 import ExpandedRows from './Examples/ExpandedRows';
 import Export from './Examples/Export';
 import StickyColumn from './Examples/StickyColumn';
+import StickyHeader from './Examples/StickyHeader';
 import ClearFiltersAndSort from './Examples/ClearFiltersAndSort';
 import { TkAlert } from '@takeoff-ui/react';
 import CustomHeader from './Examples/CustomHeader';
@@ -130,6 +131,12 @@ The basic features of the TkTable component are demonstrated.
 This feature allows the selected columns stay in their position in case of having multiple columns that extands the space.
 
 <StickyColumn />
+
+## Sticky Header
+
+This feature allows the table header to remain fixed at the top when scrolling through large datasets. To enable sticky header functionality, you must provide a height value through the `containerStyle` prop.
+
+<StickyHeader />
 
 ## Column Arrangement
 

--- a/packages/core/src/components/tk-table/tk-table.scss
+++ b/packages/core/src/components/tk-table/tk-table.scss
@@ -50,6 +50,7 @@
         background-color: none;
         position: sticky;
         top: 0;
+        z-index: 100;
 
         tr {
           background: none;

--- a/packages/core/src/components/tk-table/tk-table.scss
+++ b/packages/core/src/components/tk-table/tk-table.scss
@@ -14,9 +14,10 @@
 
   .table-holder {
     height: 100%;
-    padding: 1px;
     overflow-x: auto;
-    overflow-y: auto;
+    border-radius: var(--radius-m-base);
+    border-style: hidden;
+    box-shadow: 0 0 0 1px var(--border-light);
 
     &::-webkit-scrollbar {
       width: 8px;
@@ -41,17 +42,14 @@
     }
 
     table {
-      display: table;
       width: 100%;
-      table-layout: auto;
       border-collapse: collapse;
-      border-radius: var(--radius-m-base);
-      border-style: hidden;
-      box-shadow: 0 0 0 1px var(--border-light);
 
       thead {
         background: none;
         background-color: none;
+        position: sticky;
+        top: 0;
 
         tr {
           background: none;
@@ -59,8 +57,6 @@
           border: none;
 
           th {
-            position: sticky;
-            top: 0;
             font-size: var(--desktop-body-s-size);
             color: var(--text-darkest);
             text-align: left;
@@ -133,6 +129,7 @@
                 &.vertical {
                   flex-direction: column;
                 }
+
                 i {
                   cursor: pointer;
                   flex-shrink: 0;
@@ -179,10 +176,13 @@
 
       tbody {
         tr {
+          &:last-child {
+            border-bottom: none;
+          }
           background: none;
           background-color: none;
           border: none;
-
+          border-bottom: 1px solid var(--border-light);
           td {
             font-size: var(--desktop-body-s-size);
             color: var(--text-dark);
@@ -191,7 +191,7 @@
             background-color: var(--static-light);
             padding: var(--table-items-body-base-text-v-padding) var(--table-items-head-small-text-h-padding);
             border: none;
-            border-bottom: 1px solid var(--border-light);
+
             vertical-align: middle;
 
             &.non-text {
@@ -300,6 +300,7 @@
 
   &.base table thead tr .icons {
     gap: 8px;
+
     i {
       font-size: 20px;
       width: 20px;
@@ -311,12 +312,14 @@
     table thead tr {
       .icons {
         gap: 4px;
+
         i {
           font-size: 18px;
           width: 18px;
           height: 18px;
         }
       }
+
       th {
         padding: var(--table-items-head-small-text-v-padding);
       }
@@ -335,12 +338,14 @@
     table thead tr {
       .icons {
         gap: 2px;
+
         i {
           font-size: 16px;
           width: 16px;
           height: 16px;
         }
       }
+
       th {
         padding: var(--table-items-head-xsmall-text-v-padding) var(--table-items-head-xsmall-text-h-padding);
         font-size: var(--desktop-body-xs-size);


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a sticky header feature for the table component, ensuring the header remains fixed during scrolling. It includes a new StickyHeader component, CSS modifications for improved styling, and documentation updates, all aimed at enhancing user experience with the table interface.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
-->
</div>