### PR TITLE
Fix sticky columns and shadow on table component

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.scss
+++ b/packages/core/src/components/tk-table/tk-table.scss
@@ -14,9 +14,10 @@
 
   .table-holder {
     height: 100%;
-    padding: 1px;
     overflow-x: auto;
-    overflow-y: auto;
+    border-radius: var(--radius-m-base);
+    border-style: hidden;
+    box-shadow: 0 0 0 1px var(--border-light);
 
     &::-webkit-scrollbar {
       width: 8px;
@@ -41,17 +42,14 @@
     }
 
     table {
-      display: table;
       width: 100%;
-      table-layout: auto;
       border-collapse: collapse;
-      border-radius: var(--radius-m-base);
-      border-style: hidden;
-      box-shadow: 0 0 0 1px var(--border-light);
 
       thead {
         background: none;
         background-color: none;
+        position: sticky;
+        top: 0;
 
         tr {
           background: none;
@@ -59,8 +57,6 @@
           border: none;
 
           th {
-            position: sticky;
-            top: 0;
             font-size: var(--desktop-body-s-size);
             color: var(--text-darkest);
             text-align: left;
@@ -133,6 +129,7 @@
                 &.vertical {
                   flex-direction: column;
                 }
+
                 i {
                   cursor: pointer;
                   flex-shrink: 0;
@@ -179,10 +176,13 @@
 
       tbody {
         tr {
+          &:last-child {
+            border-bottom: none;
+          }
           background: none;
           background-color: none;
           border: none;
-
+          border-bottom: 1px solid var(--border-light);
           td {
             font-size: var(--desktop-body-s-size);
             color: var(--text-dark);
@@ -191,7 +191,7 @@
             background-color: var(--static-light);
             padding: var(--table-items-body-base-text-v-padding) var(--table-items-head-small-text-h-padding);
             border: none;
-            border-bottom: 1px solid var(--border-light);
+
             vertical-align: middle;
 
             &.non-text {
@@ -300,6 +300,7 @@
 
   &.base table thead tr .icons {
     gap: 8px;
+
     i {
       font-size: 20px;
       width: 20px;
@@ -311,12 +312,14 @@
     table thead tr {
       .icons {
         gap: 4px;
+
         i {
           font-size: 18px;
           width: 18px;
           height: 18px;
         }
       }
+
       th {
         padding: var(--table-items-head-small-text-v-padding);
       }
@@ -335,12 +338,14 @@
     table thead tr {
       .icons {
         gap: 2px;
+
         i {
           font-size: 16px;
           width: 16px;
           height: 16px;
         }
       }
+
       th {
         padding: var(--table-items-head-xsmall-text-v-padding) var(--table-items-head-xsmall-text-h-padding);
         font-size: var(--desktop-body-xs-size);

--- a/packages/core/src/components/tk-table/tk-table.scss
+++ b/packages/core/src/components/tk-table/tk-table.scss
@@ -149,14 +149,6 @@
               }
             }
           }
-
-          th:first-child {
-            border-top-left-radius: var(--radius-m-base);
-          }
-
-          th:last-child {
-            border-top-right-radius: var(--radius-m-base);
-          }
         }
 
         &.dark {
@@ -220,14 +212,6 @@
             }
           }
 
-          &:last-child td:first-child {
-            border-bottom-left-radius: var(--radius-m-base);
-          }
-
-          &:last-child td:last-child {
-            border-bottom-right-radius: var(--radius-m-base);
-          }
-
           &:hover td {
             background-color: var(--background-lightest);
           }
@@ -254,10 +238,22 @@
 
       .tk-table-left-sticky {
         position: sticky;
+        left: var(--tk-table-sticky-left-offset, 0);
       }
 
       .tk-table-right-sticky {
         position: sticky;
+        right: var(--tk-table-sticky-right-offset, 0);
+      }
+
+      thead tr th.tk-table-left-sticky {
+        left: var(--tk-table-sticky-left-offset, 0);
+        z-index: 11;
+      }
+
+      thead tr th.tk-table-right-sticky {
+        right: var(--tk-table-sticky-right-offset, 0);
+        z-index: 11;
       }
 
       .tk-table-sticky-shadow-right {

--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -260,6 +260,9 @@ export class TkTable implements ComponentInterface {
     this.customHeaderElements?.forEach(element => {
       element?.ref?.replaceChildren(element.element);
     });
+
+    // Ensure sticky shadows are correct after any render update (e.g., expand/collapse)
+    this.refreshStickyShadows();
   }
 
   componentWillUpdate(): Promise<void> | void {
@@ -521,6 +524,9 @@ export class TkTable implements ComponentInterface {
     this.expandedRows = newExpandedRows;
 
     this.tkExpandedRowsChange.emit(this.expandedRows);
+
+    // After state change, recalc shadows on next frame
+    requestAnimationFrame(() => this.refreshStickyShadows());
   }
 
   private clearCustomElements() {
@@ -1189,42 +1195,48 @@ export class TkTable implements ComponentInterface {
     const tableHolder = this.el.shadowRoot?.querySelector('.table-holder');
     if (tableHolder) {
       tableHolder.addEventListener('scroll', this.handleScroll.bind(this));
+      // Initialize shadow state on mount
+      this.handleScroll({ target: tableHolder } as unknown as Event);
     }
   }
 
   private handleScroll = (e: Event) => {
     const target = e.target as HTMLElement;
+
     const scrollLeft = target.scrollLeft;
     const scrollWidth = target.scrollWidth;
     const clientWidth = target.clientWidth;
-    const maxScrollLeft = scrollWidth - clientWidth;
+    const maxScrollLeft = Math.max(0, scrollWidth - clientWidth);
+
+    const EPS = 1; // tolerance for float rounding
+    const hasOverflow = scrollWidth > clientWidth + EPS;
+    const atLeft = scrollLeft <= EPS;
+    const atRight = scrollLeft >= maxScrollLeft - EPS;
 
     // Update shadow visibility based on scroll position
     const leftStickyElements = this.el.shadowRoot?.querySelectorAll('.tk-table-sticky-shadow-right');
     const rightStickyElements = this.el.shadowRoot?.querySelectorAll('.tk-table-sticky-shadow-left');
 
-    // Show/hide left sticky shadow
+    // Left shadow visibility
     if (leftStickyElements) {
       leftStickyElements.forEach((el: HTMLElement) => {
-        if (scrollLeft > 0) {
-          el.style.setProperty('--shadow-opacity', '1');
-        } else {
-          el.style.setProperty('--shadow-opacity', '0');
-        }
+        el.style.setProperty('--shadow-opacity', hasOverflow && !atLeft ? '1' : '0');
       });
     }
 
-    // Show/hide right sticky shadow
+    // Right shadow visibility
     if (rightStickyElements) {
       rightStickyElements.forEach((el: HTMLElement) => {
-        if (scrollLeft < maxScrollLeft) {
-          el.style.setProperty('--shadow-opacity', '1');
-        } else {
-          el.style.setProperty('--shadow-opacity', '0');
-        }
+        el.style.setProperty('--shadow-opacity', hasOverflow && !atRight ? '1' : '0');
       });
     }
   };
+
+  private refreshStickyShadows() {
+    const tableHolder = this.el.shadowRoot?.querySelector('.table-holder');
+    if (!tableHolder) return;
+    this.handleScroll({ target: tableHolder } as unknown as Event);
+  }
 
   private getStickyColumnClasses(col: ITableColumn, isFirst: boolean = false, isLast: boolean = false) {
     const classes = [];
@@ -1293,6 +1305,20 @@ export class TkTable implements ComponentInterface {
     return style;
   }
 
+  private getSelectionStickyStyle(rowIndex?: number) {
+    const style: any = {};
+
+    // Selection column is always the left-most sticky column
+    style['--tk-table-sticky-left-offset'] = `0px`;
+    style['left'] = `0px`;
+
+    if (rowIndex !== undefined) {
+      style['zIndex'] = Math.max(99 - (rowIndex ?? 0), 0);
+    }
+
+    return style;
+  }
+
   private createHead() {
     this.customHeaderElements = [];
 
@@ -1300,8 +1326,12 @@ export class TkTable implements ComponentInterface {
     let selectionTh;
 
     if (this.selectionMode === 'checkbox') {
+      const leftColumns = this.columns.filter(c => c.fixed === 'left');
       selectionTh = (
-        <th style={{ width: '20px', maxWidth: '20px' }} class="non-text">
+        <th
+          style={{ width: '20px', maxWidth: '20px', ...this.getSelectionStickyStyle() }}
+          class={classNames('non-text', 'tk-table-left-sticky', 'tk-table-sticky-first', { 'tk-table-sticky-shadow-right': leftColumns.length === 0 })}
+        >
           <tk-checkbox
             value={Array.isArray(this.selection) && this.selection.length === this.renderData.length && this.renderData.length > 0}
             disabled={!(this.renderData.length > 0)}
@@ -1311,7 +1341,13 @@ export class TkTable implements ComponentInterface {
         </th>
       );
     } else if (this.selectionMode === 'radio') {
-      selectionTh = <th style={{ width: '20px', maxWidth: '20px' }} class="non-text"></th>;
+      const leftColumns = this.columns.filter(c => c.fixed === 'left');
+      selectionTh = (
+        <th
+          style={{ width: '20px', maxWidth: '20px', ...this.getSelectionStickyStyle() }}
+          class={classNames('non-text', 'tk-table-left-sticky', 'tk-table-sticky-first', { 'tk-table-sticky-shadow-right': leftColumns.length === 0 })}
+        ></th>
+      );
     }
 
     return (
@@ -1464,7 +1500,7 @@ export class TkTable implements ComponentInterface {
             let selectionTd;
             if (this.selectionMode === 'checkbox') {
               selectionTd = (
-                <td class="non-text">
+                <td class={classNames('non-text', 'tk-table-left-sticky', 'tk-table-sticky-first')} style={this.getSelectionStickyStyle(index)}>
                   <tk-checkbox
                     value={_.some(this.selection, itemValue => _.isEqual(itemValue, row))}
                     disabled={isRowDisabled}
@@ -1474,7 +1510,7 @@ export class TkTable implements ComponentInterface {
               );
             } else if (this.selectionMode === 'radio') {
               selectionTd = (
-                <td class="non-text">
+                <td class={classNames('non-text', 'tk-table-left-sticky', 'tk-table-sticky-first')} style={this.getSelectionStickyStyle(index)}>
                   <tk-radio
                     value={row}
                     name="selection"


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the table component by improving sticky header behavior and visual effects. It includes better CSS management for borders and shadows, along with refined TypeScript logic for shadow recalculation, aiming to enhance user experience.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
-->
</div>