### PR TITLE
Correct input value assignment when value change on input component

### DIFF
--- a/packages/core/src/components/tk-input/tk-input.tsx
+++ b/packages/core/src/components/tk-input/tk-input.tsx
@@ -156,8 +156,12 @@ export class TkInput implements ComponentInterface {
   @Prop({ mutable: true }) value?: string | string[] | number | any[];
   @Watch('value')
   protected valueChanged(newValue, oldValue) {
-    if (_.isEqual(newValue, oldValue) && this.mode !== 'chips') {
-      this.nativeInput.value = newValue;
+    if (!_.isEqual(newValue, oldValue) && this.mode !== 'chips') {
+      if (typeof newValue === 'object' && typeof oldValue === 'object') {
+        this.nativeInput.value = this.getNestedValue(newValue, this.chipLabelKey);
+      } else {
+        this.nativeInput.value = newValue;
+      }
     }
   }
 


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the input component by improving the logic for handling value changes, ensuring the native value updates correctly based on the new value type. It specifically addresses an issue with value assignment when the input mode is not set to 'chips'.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on logic improvements, making the review process relatively simple.
-->
</div>