### PR TITLE
Fix sticky column shadow of expand row on table component

### DIFF
--- a/packages/core/src/components/tk-table/tk-table.tsx
+++ b/packages/core/src/components/tk-table/tk-table.tsx
@@ -268,6 +268,7 @@ export class TkTable implements ComponentInterface {
     if (this.isSelectionUpdating) {
       this.isSelectionUpdating = false;
     }
+    this.refreshStickyShadows();
   }
 
   componentWillUpdate(): Promise<void> | void {


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the tk-table component by ensuring that sticky column shadows refresh correctly when the selection is updated, enhancing visual consistency during user interactions.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on a specific bug fix, making the review process relatively simple.
-->
</div>