### PR TITLE
Maskless phone number entry feature added to phone input

### DIFF
--- a/docs/src/docs-files/tk-phone-input/Examples/CustomCountryList.tsx
+++ b/docs/src/docs-files/tk-phone-input/Examples/CustomCountryList.tsx
@@ -37,6 +37,7 @@ const CustomCountryList = () => {
     { label: 'Japan', id: 'JP', dialCode: '+81', mask: '99-9999-9999' },
     { label: 'Portugal', id: 'PT', dialCode: '+351', mask: '999 999 999' },
     { label: 'Turkey', id: 'TR', dialCode: '+90', mask: '(999) 999 9999' },
+    { label: 'None', id: 'NO' },
   ];
 
   const demo = (

--- a/docs/src/docs-files/tk-phone-input/api.mdx
+++ b/docs/src/docs-files/tk-phone-input/api.mdx
@@ -49,9 +49,9 @@ interface ICountry {
   /** The ISO country code */
   id: string;
   /** The international dialing code with + prefix */
-  dialCode: string;
+  dialCode?: string;
   /** The phone number mask pattern where 9 represents a digit */
-  mask: string;
+  mask?: string;
 }
 ```
 

--- a/docs/src/docs-files/tk-phone-input/body.mdx
+++ b/docs/src/docs-files/tk-phone-input/body.mdx
@@ -20,7 +20,8 @@ You can provide a custom list of countries to the phone input. This allows you t
     { label: 'Brazil', id: 'BR', dialCode: '+55', mask: '(99) 99999-9999' },
     { label: 'Japan', id: 'JP', dialCode: '+81', mask: '99-9999-9999' },
     { label: 'Portugal', id: 'PT', dialCode: '+351', mask: '999 999 999' },
-    { label: 'Turkey', id: 'TR', dialCode: '+90', mask: '(999) 999 9999' }
+    { label: 'Turkey', id: 'TR', dialCode: '+90', mask: '(999) 999 9999' },
+    { label: 'None', id: 'NO' },
   ]
 ```
 

--- a/packages/core/src/components/tk-phone-input/constants.ts
+++ b/packages/core/src/components/tk-phone-input/constants.ts
@@ -247,5 +247,4 @@ export const INTERNAL_COUNTRIES: ICountry[] = [
   { label: 'Yemen', id: 'YE', dialCode: '+967', mask: '999 999 999' },
   { label: 'Zambia', id: 'ZM', dialCode: '+260', mask: '99-9999999' },
   { label: 'Zimbabwe', id: 'ZW', dialCode: '+263', mask: '99 999-9999' },
-  { label: 'Other', id: 'OT' },
 ];

--- a/packages/core/src/components/tk-phone-input/constants.ts
+++ b/packages/core/src/components/tk-phone-input/constants.ts
@@ -247,4 +247,5 @@ export const INTERNAL_COUNTRIES: ICountry[] = [
   { label: 'Yemen', id: 'YE', dialCode: '+967', mask: '999 999 999' },
   { label: 'Zambia', id: 'ZM', dialCode: '+260', mask: '99-9999999' },
   { label: 'Zimbabwe', id: 'ZW', dialCode: '+263', mask: '99 999-9999' },
+  { label: 'Other', id: 'OT' },
 ];

--- a/packages/core/src/components/tk-phone-input/interfaces.ts
+++ b/packages/core/src/components/tk-phone-input/interfaces.ts
@@ -8,9 +8,9 @@ export interface ICountry {
   /** The ISO country code */
   id: string;
   /** The international dialing code with + prefix */
-  dialCode: string;
+  dialCode?: string;
   /** The phone number mask pattern where 9 represents a digit */
-  mask: string;
+  mask?: string;
 }
 
 /**

--- a/packages/core/src/components/tk-phone-input/tk-phone-input.scss
+++ b/packages/core/src/components/tk-phone-input/tk-phone-input.scss
@@ -205,6 +205,10 @@
         align-items: center;
         gap: var(--spacing-xs);
         border-right: var(--spacing-px) solid var(--border-light);
+
+        &--no-dial-code {
+          padding-right: var(--input-external-label-large-label-h-padding);
+        }
       }
       &-dial-code {
         padding-right: var(--input-external-label-large-label-h-padding);

--- a/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
+++ b/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
@@ -29,7 +29,7 @@ export class TkPhoneInput implements ComponentInterface {
    * Reference to the country search input element.
    */
   private searchInput!: HTMLTkInputElement;
-  private cleanup?: () => unknown;
+  private cleanup;
   private panelRef?: HTMLDivElement;
 
   /**
@@ -201,6 +201,10 @@ export class TkPhoneInput implements ComponentInterface {
     }
   }
 
+  formResetCallback() {
+    this.handleFormReset();
+  }
+
   /**
    * Initialize the list of countries from the provided prop or fallback to internal list.
    */
@@ -270,7 +274,7 @@ export class TkPhoneInput implements ComponentInterface {
   /**
    * Get the filtered list of countries based on the search term.
    */
-  private getFilteredCountries() {
+  private getFilteredCountries(): ICountry[] {
     const term = this.searchTerm.toLowerCase();
     if (!term) return this.countries;
 
@@ -325,6 +329,8 @@ export class TkPhoneInput implements ComponentInterface {
     if (!this.selectedCountry.mask?.length) {
       this.inputValue = rawValue;
       this.inputRef.value = this.inputValue;
+
+      // reassign the value object and emit the change event before returning. Masked Value consists of raw value
       this.value = {
         rawValue,
         maskedValue: rawValue,
@@ -391,13 +397,18 @@ export class TkPhoneInput implements ComponentInterface {
   };
 
   private renderLabel() {
-    if (!this.label?.length) return;
-    return (
-      <label htmlFor="phone-input" class="tk-phone-input__label">
-        <span class="tk-phone-input__label-title">{this.label}</span>
-        {this.showAsterisk ?? <span class="tk-phone-input__label-red-asterisk">*</span>}
-      </label>
-    );
+    let label;
+    if (this.label?.length > 0) {
+      const asterisk = <span class="tk-phone-input__label-red-asterisk">*</span>;
+      label = (
+        <label htmlFor="phone-input" class="tk-phone-input__label">
+          <span class="tk-phone-input__label-title">{this.label}</span>
+          {this.showAsterisk ? asterisk : ''}
+        </label>
+      );
+    }
+
+    return label;
   }
 
   /**
@@ -421,8 +432,9 @@ export class TkPhoneInput implements ComponentInterface {
    * Create the dropdown button for selecting a country.
    */
   private renderDropdownButton() {
-    let selectedClass = 'tk-phone-input__dropdown-button-selected';
-    if (!this.selectedCountry.dialCode) selectedClass += ' tk-phone-input__dropdown-button-selected--no-dial-code';
+    const selectedClass = classNames('tk-phone-input__dropdown-button-selected', {
+      'tk-phone-input__dropdown-button-selected--no-dial-code': !this.selectedCountry.dialCode,
+    });
 
     return (
       <button class="tk-phone-input__dropdown-button" onClick={this.toggleDropdown} type="button">
@@ -503,10 +515,11 @@ export class TkPhoneInput implements ComponentInterface {
   }
 
   private renderHint() {
-    const hintIcon = <tk-icon {...getIconElementProps('info', { class: 'tk-phone-input__hint-icon', variant: null })} />;
+    let hint;
 
-    if (!!this.hint?.length) {
-      return (
+    if (this.hint?.length > 0) {
+      const hintIcon = <tk-icon {...getIconElementProps('info', { class: 'tk-phone-input__hint-icon', variant: null })} />;
+      hint = (
         <span class="tk-phone-input__hint">
           {hintIcon}
           <span class="tk-phone-input__hint-text">{this.hint}</span>
@@ -514,8 +527,9 @@ export class TkPhoneInput implements ComponentInterface {
       );
     }
 
-    if (!!this.error?.length) {
-      return (
+    if (this.error?.length > 0) {
+      const hintIcon = <tk-icon {...getIconElementProps('info', { class: 'tk-phone-input__hint-icon', variant: null })} />;
+      hint = (
         <span class="tk-phone-input__hint">
           {hintIcon}
           <span class="tk-phone-input__hint-text">{this.error}</span>
@@ -523,7 +537,7 @@ export class TkPhoneInput implements ComponentInterface {
       );
     }
 
-    return;
+    return hint;
   }
 
   /**

--- a/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
+++ b/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
@@ -325,6 +325,16 @@ export class TkPhoneInput implements ComponentInterface {
     if (!this.selectedCountry.mask?.length) {
       this.inputValue = rawValue;
       this.inputRef.value = this.inputValue;
+      this.value = {
+        rawValue,
+        maskedValue: rawValue,
+        country: {
+          id: this.selectedCountry.id,
+          label: this.selectedCountry.label,
+          dialCode: this.selectedCountry.dialCode,
+        },
+      };
+      this.tkChange.emit(this.value);
       return;
     }
 

--- a/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
+++ b/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
@@ -282,6 +282,13 @@ export class TkPhoneInput implements ComponentInterface {
   }
 
   /**
+   * Get the flag class based on the country object.
+   */
+  private getFlagClass(country: ICountry): string {
+    return classNames('flag', { [`flag-${country.id.toLowerCase()}`]: !!country.dialCode });
+  }
+
+  /**
    * Handle country selection from the dropdown.
    */
   private handleCountrySelect = (country: ICountry): void => {
@@ -443,7 +450,7 @@ export class TkPhoneInput implements ComponentInterface {
           <img
             src="https://primefaces.org/cdn/primevue/images/flag/flag_placeholder.png"
             alt={`${this.selectedCountry.label} flag`}
-            class={`flag flag-${this.selectedCountry.id.toLowerCase()}`}
+            class={this.getFlagClass(this.selectedCountry)}
           />
           {this.selectedCountry.dialCode && <span class="tk-phone-input__dropdown-button-dial-code">{this.selectedCountry.dialCode}</span>}
         </div>
@@ -484,7 +491,7 @@ export class TkPhoneInput implements ComponentInterface {
             role="option"
             aria-selected={country.id === this.selectedCountry.id}
           >
-            <img src="https://primefaces.org/cdn/primevue/images/flag/flag_placeholder.png" alt={`${country.label} flag`} class={`flag flag-${country.id.toLowerCase()}`} />
+            <img src="https://primefaces.org/cdn/primevue/images/flag/flag_placeholder.png" alt={`${country.label} flag`} class={this.getFlagClass(country)} />
             <span class="tk-phone-input__dropdown-menu-list-country-label">{country.label}</span>
             {country.dialCode && <span class="tk-phone-input__dropdown-menu-list-dial-id">{country.dialCode}</span>}
           </li>

--- a/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
+++ b/packages/core/src/components/tk-phone-input/tk-phone-input.tsx
@@ -29,7 +29,7 @@ export class TkPhoneInput implements ComponentInterface {
    * Reference to the country search input element.
    */
   private searchInput!: HTMLTkInputElement;
-  private cleanup;
+  private cleanup?: () => unknown;
   private panelRef?: HTMLDivElement;
 
   /**
@@ -201,10 +201,6 @@ export class TkPhoneInput implements ComponentInterface {
     }
   }
 
-  formResetCallback() {
-    this.handleFormReset();
-  }
-
   /**
    * Initialize the list of countries from the provided prop or fallback to internal list.
    */
@@ -212,7 +208,7 @@ export class TkPhoneInput implements ComponentInterface {
     if (this.countryList) {
       this.countries = this.countryList;
     } else {
-      this.countries = INTERNAL_COUNTRIES as ICountry[];
+      this.countries = INTERNAL_COUNTRIES;
     }
   }
 
@@ -227,7 +223,8 @@ export class TkPhoneInput implements ComponentInterface {
   /**
    * Apply the mask to a raw phone number.
    */
-  private applyMask(rawValue: string, mask: string): string {
+  private applyMask(rawValue: string, mask: string | undefined) {
+    if (!mask?.length || !rawValue?.length) return rawValue;
     let maskedValue = '';
     let digitIndex = 0;
 
@@ -273,11 +270,11 @@ export class TkPhoneInput implements ComponentInterface {
   /**
    * Get the filtered list of countries based on the search term.
    */
-  private getFilteredCountries(): ICountry[] {
+  private getFilteredCountries() {
     const term = this.searchTerm.toLowerCase();
     if (!term) return this.countries;
 
-    return this.countries.filter(country => country.label.toLowerCase().includes(term) || country.dialCode.includes(term));
+    return this.countries.filter(country => country.label.toLowerCase().includes(term) || country?.dialCode.includes(term));
   }
 
   /**
@@ -321,17 +318,21 @@ export class TkPhoneInput implements ComponentInterface {
   /**
    * Handle changes to the phone number input.
    */
-  private handleInput = (event: Event): void => {
+  private handleInput = (event: Event) => {
     const inputElement = event.target as HTMLInputElement;
     const rawValue = inputElement.value.replace(/\D/g, '');
+
+    if (!this.selectedCountry.mask?.length) {
+      this.inputValue = rawValue;
+      this.inputRef.value = this.inputValue;
+      return;
+    }
+
     const currentMask = this.selectedCountry.mask;
     const maxDigits = (currentMask.match(/9/g) || []).length;
     const hasNoDigits = /[^\d() ]/.test(inputElement.value);
 
-    if (rawValue.length > maxDigits || hasNoDigits) {
-      this.inputRef.value = this.inputValue;
-      return;
-    }
+    if (rawValue.length > maxDigits || hasNoDigits) return (this.inputRef.value = this.inputValue);
 
     this.hasFocus = false;
     this.inputValue = this.applyMask(rawValue, currentMask);
@@ -380,18 +381,13 @@ export class TkPhoneInput implements ComponentInterface {
   };
 
   private renderLabel() {
-    let label;
-    if (this.label?.length > 0) {
-      const asterisk = <span class="tk-phone-input__label-red-asterisk">*</span>;
-      label = (
-        <label htmlFor="phone-input" class="tk-phone-input__label">
-          <span class="tk-phone-input__label-title">{this.label}</span>
-          {this.showAsterisk ? asterisk : ''}
-        </label>
-      );
-    }
-
-    return label;
+    if (!this.label?.length) return;
+    return (
+      <label htmlFor="phone-input" class="tk-phone-input__label">
+        <span class="tk-phone-input__label-title">{this.label}</span>
+        {this.showAsterisk ?? <span class="tk-phone-input__label-red-asterisk">*</span>}
+      </label>
+    );
   }
 
   /**
@@ -415,16 +411,19 @@ export class TkPhoneInput implements ComponentInterface {
    * Create the dropdown button for selecting a country.
    */
   private renderDropdownButton() {
+    let selectedClass = 'tk-phone-input__dropdown-button-selected';
+    if (!this.selectedCountry.dialCode) selectedClass += ' tk-phone-input__dropdown-button-selected--no-dial-code';
+
     return (
       <button class="tk-phone-input__dropdown-button" onClick={this.toggleDropdown} type="button">
-        <div class="tk-phone-input__dropdown-button-selected">
+        <div class={selectedClass}>
           <tk-icon {...getIconElementProps('stat_minus_1', { variant: null, size: 'large' }, undefined, 'span')} />
           <img
             src="https://primefaces.org/cdn/primevue/images/flag/flag_placeholder.png"
             alt={`${this.selectedCountry.label} flag`}
             class={`flag flag-${this.selectedCountry.id.toLowerCase()}`}
           />
-          <span class="tk-phone-input__dropdown-button-dial-code">{this.selectedCountry.dialCode}</span>
+          {this.selectedCountry.dialCode && <span class="tk-phone-input__dropdown-button-dial-code">{this.selectedCountry.dialCode}</span>}
         </div>
       </button>
     );
@@ -465,7 +464,7 @@ export class TkPhoneInput implements ComponentInterface {
           >
             <img src="https://primefaces.org/cdn/primevue/images/flag/flag_placeholder.png" alt={`${country.label} flag`} class={`flag flag-${country.id.toLowerCase()}`} />
             <span class="tk-phone-input__dropdown-menu-list-country-label">{country.label}</span>
-            <span class="tk-phone-input__dropdown-menu-list-dial-id">{country.dialCode}</span>
+            {country.dialCode && <span class="tk-phone-input__dropdown-menu-list-dial-id">{country.dialCode}</span>}
           </li>
         ))}
       </ul>
@@ -482,7 +481,7 @@ export class TkPhoneInput implements ComponentInterface {
         id="phone-input"
         class="tk-phone-input__input"
         autoComplete="off"
-        placeholder={this.placeholder || this.selectedCountry.mask.replace(/9/g, '9')}
+        placeholder={this.placeholder || this.selectedCountry.mask?.replace(/9/g, '9')}
         value={this.inputValue}
         onInput={this.handleInput}
         onBlur={this.handleInputBlur}
@@ -493,13 +492,11 @@ export class TkPhoneInput implements ComponentInterface {
     );
   }
 
-  private renderHint(): HTMLSpanElement {
-    let hint;
+  private renderHint() {
+    const hintIcon = <tk-icon {...getIconElementProps('info', { class: 'tk-phone-input__hint-icon', variant: null })} />;
 
-    if (this.hint?.length > 0) {
-      const hintIcon = <tk-icon {...getIconElementProps('info', { class: 'tk-phone-input__hint-icon', variant: null })} />;
-
-      hint = (
+    if (!!this.hint?.length) {
+      return (
         <span class="tk-phone-input__hint">
           {hintIcon}
           <span class="tk-phone-input__hint-text">{this.hint}</span>
@@ -507,10 +504,8 @@ export class TkPhoneInput implements ComponentInterface {
       );
     }
 
-    if (this.error?.length > 0) {
-      const hintIcon = <tk-icon {...getIconElementProps('info', { class: 'tk-phone-input__hint-icon', variant: null })} />;
-
-      hint = (
+    if (!!this.error?.length) {
+      return (
         <span class="tk-phone-input__hint">
           {hintIcon}
           <span class="tk-phone-input__hint-text">{this.error}</span>
@@ -518,7 +513,7 @@ export class TkPhoneInput implements ComponentInterface {
       );
     }
 
-    return hint;
+    return;
   }
 
   /**


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the phone input component by adding a new 'Other' option for non-specific country selection, making dialing code and mask fields optional, refining hint rendering logic, and updating documentation for improved user experience and maintainability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>