### PR TITLE
 Add list tag's styling support to editor component

### DIFF
--- a/packages/core/src/components/tk-editor/tk-editor.scss
+++ b/packages/core/src/components/tk-editor/tk-editor.scss
@@ -470,6 +470,22 @@
     }
   }
 
+  ul {
+    list-style-type: disc;
+
+    li {
+      display: list-item;
+    }
+  }
+
+  ol {
+    list-style-type: decimal;
+
+    li {
+      display: list-item;
+    }
+  }
+
   h1,
   h2,
   h3,


### PR DESCRIPTION
TkEditor was not displaying some list tags correctly. 
The necessary style rules were added for this. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the styling of list tags in the TkEditor component by introducing new CSS rules for better display of unordered and ordered lists, improving the overall presentation and addressing previous display issues.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve CSS adjustments, making the review process relatively simple.
-->
</div>