### PR TITLE
Add optional chaining to setValue function of the select component to prevent errors

### DIFF
--- a/packages/core/src/components/tk-select/tk-select.tsx
+++ b/packages/core/src/components/tk-select/tk-select.tsx
@@ -464,15 +464,15 @@ export class TkSelect implements ComponentInterface {
     }
 
     // Find the selected item based on value type
-    if (typeof this.value !== 'object' && innerOptions.every(item => typeof item !== 'object')) {
+    if (typeof this.value !== 'object' && innerOptions?.every(item => typeof item !== 'object')) {
       // Handle primitive values
-      this.selectedItem = innerOptions.find(item => item === this.value);
+      this.selectedItem = innerOptions?.find(item => item === this.value);
     } else if (this.optionValueKey?.length > 0) {
       // Handle object values with optionValueKey
-      this.selectedItem = innerOptions.find(item => this.getOptionValue(item) === this.value);
+      this.selectedItem = innerOptions?.find(item => this.getOptionValue(item) === this.value);
     } else {
       // Handle object values without optionValueKey
-      this.selectedItem = innerOptions.find(item => _.isEqual(item, this.value));
+      this.selectedItem = innerOptions?.find(item => _.isEqual(item, this.value));
     }
 
     // Set input value based on selection state


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the tk-select component by implementing optional chaining to safeguard against errors when accessing the innerOptions array. This enhancement improves the component's reliability in scenarios where innerOptions may be undefined.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on error handling, making the review process relatively simple.
-->
</div>