### PR TITLE
Set minimum height for tk-spinner to prevent scroll flick problem in select component.

### DIFF
--- a/packages/core/src/components/tk-select/tk-select.scss
+++ b/packages/core/src/components/tk-select/tk-select.scss
@@ -92,6 +92,9 @@ tk-select {
       .dropdown-item {
         font-size: var(--desktop-body-m-base-size);
       }
+      tk-spinner {
+        min-height: 48px;
+      }
     }
   }
 
@@ -100,6 +103,9 @@ tk-select {
       .dropdown-item {
         font-size: var(--desktop-body-s-size);
       }
+      tk-spinner {
+        min-height: 38px;
+      }
     }
   }
 
@@ -107,6 +113,9 @@ tk-select {
     .dropdown-item-holder {
       .dropdown-item {
         font-size: var(--desktop-body-xs-size);
+      }
+      tk-spinner {
+        min-height: 28px;
       }
     }
   }


### PR DESCRIPTION
when loading prop is true, the spinner inside the dropdown was making scrollbar appear and disappear, which caused a flicker. fixed by adding a min-height per size variant to tk-spinner inside the dropdown, stabilizing the holder's height.