### PR TITLE
Update documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ across packages.
 ## Documentation
 
 Full API reference, guides, and examples are available at:  
-https://takeoff-ui.thy.com/docs
+[https://takeoff-ui.thy.com/docs](https://www.takeoffui.com/docs/Introduction)
 
 ## Contributing
 


### PR DESCRIPTION
Hello, I noticed that the documentation link in the README points to "https://takeoff-ui.thy.com/docs", but it seems the new documentation is actually located at "https://www.takeoffui.com/docs/Introduction". Just wanted to let you know so it can be updated