### PR TITLE
fix(tk-popover): Render panel in top layer to fix sticky table z-index

### DIFF
--- a/.changeset/popover-top-layer.md
+++ b/.changeset/popover-top-layer.md
@@ -1,0 +1,9 @@
+---
+'@takeoff-ui/core': patch
+---
+
+fix(tk-popover): render the open panel in the browser top layer via the native
+Popover API so it can no longer be hidden behind sticky `tk-table` cells. The
+panel stays inside the component's shadow root, so slotted content, scoped
+styles and click-outside dismissal are unaffected. No-ops on browsers without
+the Popover API.

--- a/packages/core/src/components/tk-popover/test/tk-popover.e2e.ts
+++ b/packages/core/src/components/tk-popover/test/tk-popover.e2e.ts
@@ -28,4 +28,24 @@ describe('tk-popover', () => {
     expect(await contentSlot.getAttribute('data-testid')).toBeNull();
     expect(changeSpy).toHaveReceivedEventDetail(true);
   });
+
+  it('renders the open panel in the top layer (native popover)', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<tk-popover><button slot="trigger">Open</button><div slot="content">Body</div></tk-popover>');
+
+    const trigger = await page.find('tk-popover [slot="trigger"]');
+    await trigger.click();
+    await page.waitForChanges();
+
+    // The panel must be promoted to the top layer so it escapes ancestor
+    // stacking contexts (the sticky-table-cell z-index bug). Assert via the
+    // :popover-open pseudo-class, which only matches top-layer popovers.
+    const isInTopLayer = await page.evaluate(() => {
+      const panel = document.querySelector('tk-popover')?.shadowRoot?.querySelector('.tk-popover-content');
+      return !!panel && panel.matches(':popover-open');
+    });
+
+    expect(isInTopLayer).toBe(true);
+  });
 });

--- a/packages/core/src/components/tk-popover/test/tk-popover.spec.tsx
+++ b/packages/core/src/components/tk-popover/test/tk-popover.spec.tsx
@@ -14,6 +14,20 @@ describe('tk-popover', () => {
     expect(page.root.shadowRoot.querySelector('.tk-popover-content')).toBeTruthy();
   });
 
+  it('renders the panel as a native popover so it lands in the top layer', async () => {
+    const page = await newSpecPage({
+      components: [TkPopover],
+      html: `<tk-popover><button slot="trigger">Open</button><div slot="content">Body</div></tk-popover>`,
+    });
+
+    page.rootInstance.isOpen = true;
+    await page.waitForChanges();
+
+    // popover="manual" escapes ancestor stacking contexts (e.g. sticky table
+    // cells) via the top layer, while leaving dismissal to ClickOutsideMixin.
+    expect(page.root.shadowRoot.querySelector('.tk-popover-content')?.getAttribute('popover')).toBe('manual');
+  });
+
   describe('dataTestid', () => {
     it('applies semantic data-testid on root, content and arrow', async () => {
       const page = await newSpecPage({

--- a/packages/core/src/components/tk-popover/tk-popover.scss
+++ b/packages/core/src/components/tk-popover/tk-popover.scss
@@ -11,6 +11,15 @@
   z-index: 1300;
   box-shadow: var(--shadow-base);
 
+  // When rendered in the top layer via the native Popover API, reset the UA
+  // defaults (inset: 0 + margin: auto would center it) so Floating UI's
+  // left/top positioning is honoured. Harmless when the API is unavailable.
+  &[popover] {
+    margin: 0;
+    inset: auto;
+    overflow: visible;
+  }
+
   &.tk-popover-dark {
     border: 1px solid var(--border-light);
     background: var(--background-darkest);

--- a/packages/core/src/components/tk-popover/tk-popover.tsx
+++ b/packages/core/src/components/tk-popover/tk-popover.tsx
@@ -134,6 +134,9 @@ export class TkPopover implements ComponentInterface {
     this.clickOutsideMixin.updateConfig({ disabled: this.isHover || !this.isOpen });
 
     if (this.isOpen) {
+      // Promote to the top layer before positioning so it cannot be trapped
+      // behind a sticky table cell's stacking context.
+      this.showInTopLayer();
       // Clean up old floating UI listeners before setting up new ones
       this.cleanup?.();
       this.updatePosition();
@@ -157,6 +160,26 @@ export class TkPopover implements ComponentInterface {
     this.cleanup = floatingElementAutoUpdate(this.triggerElement, this.popoverElement, this.arrowElement, { placement: this.position });
   }
 
+  /**
+   * Promote the panel to the browser top layer via the native Popover API.
+   * The top layer escapes every ancestor stacking context (e.g. the per-cell
+   * z-index of sticky tk-table columns), so the panel can no longer be hidden
+   * behind a neighbouring cell. The element stays inside this component's shadow
+   * root, so slotted content, scoped styles and click-outside detection keep
+   * working. No-ops when the API is unavailable (older browsers).
+   */
+  private showInTopLayer() {
+    const el = this.popoverElement as HTMLElement & { showPopover?: () => void };
+    if (typeof el?.showPopover !== 'function' || !el.isConnected) return;
+    // showPopover() throws if the element is already in the top layer.
+    if (el.matches(':popover-open')) return;
+    try {
+      el.showPopover();
+    } catch {
+      /* element not eligible (e.g. detached during a re-render) — ignore */
+    }
+  }
+
   render() {
     return (
       <div class="tk-popover" data-testid={getDataTestId(this.dataTestid, 'container')}>
@@ -164,6 +187,9 @@ export class TkPopover implements ComponentInterface {
         {this.isOpen && (
           <div
             ref={el => (this.popoverElement = el as HTMLElement)}
+            // `manual` keeps the browser's light-dismiss from fighting our
+            // ClickOutsideMixin, while still rendering the panel in the top layer.
+            popover="manual"
             class={{
               'tk-popover-content': true,
               [`tk-popover-${this.type}`]: true,


### PR DESCRIPTION
## Sorun

Sticky tablo hücrelerindeki (`col.fixed`) custom cell'lerde bir `tk-popover` açıldığında, panelin açılan kısmı **komşu/üstteki hücrenin arkasında** kalabiliyor. (Aynı sorun #526'da ele alındı.)

### Kök neden — "stacking context tuzağı"

Her sticky `<td>`, `getStickyColumnStyle` içinde `position: sticky` **+ hücreye özel bir inline `z-index`** alıyor. `position: sticky` + `auto` olmayan `z-index`, **her hücre için ayrı bir stacking context** oluşturur. Popover paneli ise `tk-popover`'ın shadow DOM'unun içinde **inline render ediliyor** (body'ye portal edilmiyor). Dolayısıyla panelin `z-index: 1300` değeri, ait olduğu `<td>`'nin stacking context'ine **hapsoluyor**; başka bir `<td>` ile karşılaştırıldığında sadece `<td>`'lerin z-index'i belirleyici oluyor ve panel daha yüksek z-index'li komşu hücrenin arkasında kalıyor.

Bu yüzden sorun **yalnızca sticky kolonlarda** görülür; normal hücreler stacking context oluşturmadığı için orada popover sorunsuz çalışır.

## Çözüm

Paneli **native HTML Popover API** ile tarayıcının **top-layer**'ına çıkarıyoruz. Top-layer tüm stacking context'lerin ve z-index'lerin dışındadır → hiçbir sticky `<td>` paneli artık gizleyemez ve z-index tamamen anlamsızlaşır.

- `tk-popover.tsx`: panel div'ine `popover="manual"` eklendi; `componentDidUpdate`'te popover açılınca `showInTopLayer()` çağrılıyor (Floating UI konumlandırmasından **önce**). Metod güvenli no-op: API yoksa, eleman bağlı değilse veya zaten açıksa hiçbir şey yapmaz, `showPopover()` `try/catch` içinde.
- `tk-popover.scss`: `&[popover]` altında UA varsayılanları (`inset: 0` + `margin: auto` ortalaması) sıfırlandı ki Floating UI'ın `left/top` konumu geçerli olsun.
- `floatingElementAutoUpdate` (paylaşılan util) ve `ClickOutsideMixin` **değiştirilmedi**.

### Neden bu yaklaşım (portal değil)?

Panel top-layer'a çıksa da **DOM'da shadow root içinde kalır**. Bunun kritik avantajı:
- **Slotted custom HTML korunur** — developer'ın popover içine koyduğu içerik bozulmaz. (Body'ye portal etmek bunu bozardı; bu yüzden portal elendi.)
- Shadow CSS encapsulation'ı korunur.
- `ClickOutsideMixin` `event.composedPath()` kullandığı için dış-tıklama ile kapanma aynen çalışır.
- Paylaşılan floating util'e dokunulmadığı için diğer bileşenler (dropdown, select, datepicker, tooltip …) etkilenmez.
- `popover="manual"` ile native light-dismiss kapalı → mevcut mixin ile çakışmaz, davranış değişmez.

### #526'ya göre farkı
- Paylaşılan `floatingElementAutoUpdate` util'ini kirletmez (#526 buraya tk-table'a özgü mantık ekliyordu → 9 bileşeni etkiliyordu).
- Sticky header'ı (`z-index: 100`) ezme regresyonu yok (#526'daki `101` değeri header'ı geçiyordu).
- Hem aşağı hem yukarı açılışta çalışır (önceki `- rowIndex` tabanlı yaklaşım #159 sadece aşağı açılışı çözmüştü).

## Doğrulama

- `stencil build` ✅ (TS + JSX + React/Vue/Angular wrapper'ları temiz derlendi)
- Spec testleri **4/4** ✅ (yeni test: panel `popover="manual"` alıyor)
- E2E testleri gerçek Chrome'da **2/2** ✅ (yeni test: açık panel `:popover-open` ile eşleşiyor → fiilen top-layer'da)

## Bilinen davranış değişikliği (PR'da bilinçli not)

`tk-dialog` / `tk-drawer` native `<dialog>`/`showModal()` kullanmıyor; normal stacking ile `z-index: 1500` kullanıyorlar. Native top-layer **her zaman** tüm z-index'lerin üstünde olduğundan, bir `tk-popover` artık görsel olarak bu bileşenlerin de üstünde boyanır (eskiden 1300 < 1500 olduğu için altında kalırdı). Pratikte:
- Popover bir dialog/drawer **içinde** açıldığında üstünde olması zaten **doğru** davranıştır.
- Popover dışarıda açıkken bir modal açılırsa görsel bir tuhaflık olabilir; ancak popover'lar genelde click-outside ile kapandığından bu senaryo nadirdir.

Bu davranış kabul edilemezse, ileride `tk-dialog`/`tk-drawer`'ı da native top-layer'a (`<dialog>` / `showModal`) taşımak tutarlı bir çözüm olur.

## Tarayıcı desteği
Chrome/Edge 114+, Safari 17+, Firefox 125+ (bugün Baseline). Desteklemeyen tarayıcılarda kod güvenle no-op'a düşer ve eski (z-index) davranışı korur — yani regresyon yaratmaz.

## Not
Aynı top-layer pattern'i ileride `tk-dropdown`, `tk-select`, `tk-datepicker`, `tk-tooltip` gibi aynı tuzaktan etkilenebilecek bileşenlere de genişletilebilir. Bu PR bilinçli olarak rapor edilen bug'a (popover) odaklanıyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)