### PR TITLE
feat(tk-input): Incremental regex mask validation

### DIFF
--- a/.changeset/tk-input-regex-mask.md
+++ b/.changeset/tk-input-regex-mask.md
@@ -1,0 +1,10 @@
+---
+'@takeoff-ui/core': minor
+---
+
+Fix and extend the `tk-input` `maskOptions.regex` mask. Typing an invalid
+character no longer wipes the field; input is now validated incrementally so
+anchored, full-value patterns (e.g. `/^[0-9,]{1,10}$/`), alternation, groups,
+and quantifiers all work as the user types, with length limits enforced.
+Unsupported syntax (lookarounds, back-references) and invalid patterns safely
+disable the mask instead of throwing.

--- a/docs/src/docs-files/tk-input/Examples/Mask.tsx
+++ b/docs/src/docs-files/tk-input/Examples/Mask.tsx
@@ -308,8 +308,7 @@ const value6 = ref();
         label="Custom Regex (PNR Code)"
         placeholder="ABC123"
         maskOptions={{
-          regex: /[A-Z0-9]/,
-          blocks: [6],
+          regex: /^[0-9,]{1,10}$/,
         }}
         value={value5}
         onTkChange={e => {

--- a/docs/src/docs-files/tk-input/Examples/RegexMask.tsx
+++ b/docs/src/docs-files/tk-input/Examples/RegexMask.tsx
@@ -1,0 +1,175 @@
+import { TkInput } from '@takeoff-ui/react';
+import FeatureDemo from '../../../components/FeatureDemo';
+import React, { useState } from 'react';
+
+const RegexMask = () => {
+  const reactCode = `// The \`regex\` mask validates input as the user types: characters that could
+// never lead to a valid value are rejected, while valid prefixes are accepted.
+// Write the regex for the FINAL value (anchors and length quantifiers are fine) —
+// intermediate states are handled for you.
+
+<TkInput
+  label="PNR Code (letters & digits, max 6)"
+  placeholder="ABC123"
+  maskOptions={{ regex: /^[A-Z0-9]{1,6}$/ }}
+  value={pnr}
+  onTkChange={(e) => setPnr(e.detail)}
+/>
+
+<TkInput
+  label="Amount (digits & commas, max 10)"
+  placeholder="1,2,3"
+  maskOptions={{ regex: /^[0-9,]{1,10}$/ }}
+  value={amount}
+  onTkChange={(e) => setAmount(e.detail)}
+/>
+
+<TkInput
+  label="Plate (2 letters + 4 digits)"
+  placeholder="AB1234"
+  maskOptions={{ regex: /^[A-Z]{2}[0-9]{4}$/ }}
+  value={plate}
+  onTkChange={(e) => setPlate(e.detail)}
+/>
+
+<TkInput
+  label="Currency"
+  placeholder="$12.34"
+  maskOptions={{ regex: /^\\$\\d+\\.\\d{2}$/ }}
+  value={price}
+  onTkChange={(e) => setPrice(e.detail)}
+/>
+
+<TkInput
+  label="Phone (optional +90 prefix)"
+  placeholder="+905551234567"
+  maskOptions={{ regex: /^(\\+90)?[0-9]{10}$/ }}
+  value={phone}
+  onTkChange={(e) => setPhone(e.detail)}
+/>
+
+<TkInput
+  label="Code (4 or 6 digits)"
+  placeholder="1234 or 123456"
+  maskOptions={{ regex: /^(\\d{4}|\\d{6})$/ }}
+  value={code}
+  onTkChange={(e) => setCode(e.detail)}
+/>`;
+
+  const vueCode = `<script setup>
+import { TkInput } from '@takeoff-ui/vue';
+
+const pnr = ref();
+const amount = ref();
+const plate = ref();
+const price = ref();
+const phone = ref();
+const code = ref();
+</script>
+
+<template>
+  <div>
+    <TkInput
+      label="PNR Code (letters & digits, max 6)"
+      placeholder="ABC123"
+      :maskOptions.prop="{ regex: /^[A-Z0-9]{1,6}$/ }"
+      v-model="pnr"
+    />
+    <TkInput
+      label="Amount (digits & commas, max 10)"
+      placeholder="1,2,3"
+      :maskOptions.prop="{ regex: /^[0-9,]{1,10}$/ }"
+      v-model="amount"
+    />
+    <TkInput
+      label="Plate (2 letters + 4 digits)"
+      placeholder="AB1234"
+      :maskOptions.prop="{ regex: /^[A-Z]{2}[0-9]{4}$/ }"
+      v-model="plate"
+    />
+    <TkInput
+      label="Currency"
+      placeholder="$12.34"
+      :maskOptions.prop="{ regex: /^\\$\\d+\\.\\d{2}$/ }"
+      v-model="price"
+    />
+    <TkInput
+      label="Phone (optional +90 prefix)"
+      placeholder="+905551234567"
+      :maskOptions.prop="{ regex: /^(\\+90)?[0-9]{10}$/ }"
+      v-model="phone"
+    />
+    <TkInput
+      label="Code (4 or 6 digits)"
+      placeholder="1234 or 123456"
+      :maskOptions.prop="{ regex: /^(\\d{4}|\\d{6})$/ }"
+      v-model="code"
+    />
+  </div>
+</template>
+`;
+
+  const angularCode = `<tk-input
+  label="PNR Code (letters & digits, max 6)"
+  placeholder="ABC123"
+  [maskOptions]="{ regex: /^[A-Z0-9]{1,6}$/ }"
+  [(ngModel)]="pnr"
+></tk-input>
+<tk-input
+  label="Amount (digits & commas, max 10)"
+  placeholder="1,2,3"
+  [maskOptions]="{ regex: /^[0-9,]{1,10}$/ }"
+  [(ngModel)]="amount"
+></tk-input>
+<tk-input
+  label="Plate (2 letters + 4 digits)"
+  placeholder="AB1234"
+  [maskOptions]="{ regex: /^[A-Z]{2}[0-9]{4}$/ }"
+  [(ngModel)]="plate"
+></tk-input>
+<tk-input
+  label="Currency"
+  placeholder="$12.34"
+  [maskOptions]="{ regex: /^\\$\\d+\\.\\d{2}$/ }"
+  [(ngModel)]="price"
+></tk-input>
+<tk-input
+  label="Phone (optional +90 prefix)"
+  placeholder="+905551234567"
+  [maskOptions]="{ regex: /^(\\+90)?[0-9]{10}$/ }"
+  [(ngModel)]="phone"
+></tk-input>
+<tk-input
+  label="Code (4 or 6 digits)"
+  placeholder="1234 or 123456"
+  [maskOptions]="{ regex: /^(\\d{4}|\\d{6})$/ }"
+  [(ngModel)]="code"
+></tk-input>`;
+
+  const [pnr, setPnr] = useState();
+  const [amount, setAmount] = useState();
+  const [plate, setPlate] = useState();
+  const [price, setPrice] = useState();
+  const [phone, setPhone] = useState();
+  const [code, setCode] = useState();
+
+  const demo = (
+    <div className="flex flex-col gap-2 w-[300px]">
+      <TkInput label="PNR Code (letters & digits, max 6)" placeholder="ABC123" maskOptions={{ regex: /^[A-Z0-9]{1,6}$/ }} value={pnr} onTkChange={e => setPnr(e.detail)} />
+
+      <TkInput label="Amount (digits & commas, max 10)" placeholder="1,2,3" maskOptions={{ regex: /^[0-9,]{1,10}$/ }} value={amount} onTkChange={e => setAmount(e.detail)} />
+
+      <TkInput label="Plate (2 letters + 4 digits)" placeholder="AB1234" maskOptions={{ regex: /^[A-Z]{2}[0-9]{4}$/ }} value={plate} onTkChange={e => setPlate(e.detail)} />
+
+      <TkInput label="Currency" placeholder="$12.34" maskOptions={{ regex: /^\$\d+\.\d{2}$/ }} value={price} onTkChange={e => setPrice(e.detail)} />
+
+      <TkInput label="Phone (optional +90 prefix)" placeholder="+905551234567" maskOptions={{ regex: /^(\+90)?[0-9]{10}$/ }} value={phone} onTkChange={e => setPhone(e.detail)} />
+
+      <TkInput label="Code (4 or 6 digits)" placeholder="1234 or 123456" maskOptions={{ regex: /^(\d{4}|\d{6})$/ }} value={code} onTkChange={e => setCode(e.detail)} />
+    </div>
+  );
+
+  return <FeatureDemo demo={demo} reactCode={reactCode} vueCode={vueCode} angularCode={angularCode}></FeatureDemo>;
+};
+
+export default RegexMask;

--- a/docs/src/docs-files/tk-input/body.mdx
+++ b/docs/src/docs-files/tk-input/body.mdx
@@ -4,6 +4,7 @@ import Basic from './Examples/Basic';
 import Password from './Examples/Password';
 import Counter from './Examples/Counter';
 import Mask from './Examples/Mask';
+import RegexMask from './Examples/RegexMask';
 import Size from './Examples/Size';
 import Clearable from './Examples/Clearable';
 import Chips from './Examples/Chips';
@@ -47,6 +48,28 @@ example, you can configure it for formatting dates, phone numbers, or credit
 card numbers as needed.
 
 <Mask />
+
+## Regex Mask
+
+For rules that Cleave.js cannot express, pass a `regex` to `maskOptions`. Write
+the pattern for the **final** value — anchors (`^ $`) and length quantifiers
+like `{1,10}` are fully supported. The input is validated **as the user types**:
+characters that could never lead to a valid value are rejected, while valid
+prefixes are accepted, so the field is never wiped when an invalid key is
+pressed.
+
+This supports the regular-language subset of JavaScript regex: character classes
+and ranges, groups and nested groups, alternation (`|`), all quantifiers
+(`* + ? {n} {n,m}`), optional groups, named groups, and non-ASCII ranges.
+
+<RegexMask />
+
+<TkAlert
+  header="Caveat"
+  variant="warning"
+  message="Lookarounds ((?=…), (?<=…)) and back-references (\1, \k<name>) cannot be validated incrementally; if used, the regex mask is disabled and a console warning is logged."
+  filledlight
+/>
 
 ## Size
 

--- a/packages/core/src/components/tk-input/test/tk-input.spec.tsx
+++ b/packages/core/src/components/tk-input/test/tk-input.spec.tsx
@@ -3,6 +3,9 @@ jest.mock('lodash-es', () => ({
   isNil: (value: unknown) => value === null || value === undefined,
 }));
 
+// uuid v14 ships pure ESM which Jest can't transform from node_modules; stub it for the suite.
+jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+
 import { newSpecPage } from '@stencil/core/testing';
 import { TkInput } from '../tk-input';
 
@@ -14,6 +17,308 @@ describe('tk-input', () => {
     });
 
     expect(page.root.querySelector('.label .asterisk')?.textContent).toBe('*');
+  });
+
+  describe('regex mask', () => {
+    // Simulates realistic typing: appends one character at a time and fires an
+    // input event after each keystroke, the way a real <input> behaves.
+    const setup = async (regex: RegExp | string) => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { regex };
+      const input = page.root.querySelector('input') as HTMLInputElement;
+      const type = (text: string) => {
+        for (const ch of text) {
+          input.value = input.value + ch;
+          input.dispatchEvent(new Event('input'));
+        }
+      };
+      return { page, input, type };
+    };
+
+    it('keeps valid characters when an invalid one is typed (anchored pattern)', async () => {
+      // Anchored, whole-string pattern is the natural way a dev writes a mask rule.
+      const { page, input, type } = await setup(/^[A-Z0-9]+$/);
+
+      type('ABC');
+      expect(input.value).toBe('ABC');
+
+      // Typing an invalid char must NOT wipe the field — it must reject only the bad char.
+      type('!');
+      expect(input.value).toBe('ABC');
+      expect(page.rootInstance.value).toBe('ABC');
+
+      // Typing continues to work after a rejected keystroke.
+      type('9');
+      expect(input.value).toBe('ABC9');
+    });
+
+    it('rejects invalid characters as they are typed (character-class pattern)', async () => {
+      const { input, type } = await setup(/^[A-Z0-9]+$/);
+
+      type('A1b2C');
+      expect(input.value).toBe('A12C');
+    });
+
+    it('accepts a string regex source', async () => {
+      const { input, type } = await setup('^[0-9]*$');
+
+      type('12a34');
+      expect(input.value).toBe('1234');
+    });
+
+    it('enforces the length limit from a {n,m} quantifier', async () => {
+      // Digits and commas, max 10 characters.
+      const { input, type } = await setup(/^[0-9,]{1,10}$/);
+
+      type('1,2,3,4,5,'); // 10 chars
+      expect(input.value).toBe('1,2,3,4,5,');
+      expect(input.value).toHaveLength(10);
+
+      // The 11th character is rejected; the value stays capped at 10.
+      type('6');
+      expect(input.value).toBe('1,2,3,4,5,');
+    });
+
+    it('enforces an exact-length {n} quantifier', async () => {
+      const { input, type } = await setup(/^[A-Z]{3}$/);
+
+      type('ABCDE');
+      expect(input.value).toBe('ABC');
+    });
+
+    it('keeps an unbounded + quantifier length-unlimited', async () => {
+      const { input, type } = await setup(/^[0-9]+$/);
+
+      type('1234567890123456');
+      expect(input.value).toBe('1234567890123456');
+    });
+
+    it('validates structural patterns incrementally (alternation)', async () => {
+      const { input, type } = await setup(/^(abc|def)$/);
+
+      type('abc');
+      expect(input.value).toBe('abc');
+      // 'x' cannot continue either branch and is rejected.
+      type('x');
+      expect(input.value).toBe('abc');
+    });
+
+    it('validates positional patterns incrementally (letters then digits)', async () => {
+      const { page, input, type } = await setup(/^[A-Z]{2}[0-9]{4}$/);
+
+      type('AB'); // letters accepted
+      expect(input.value).toBe('AB');
+      type('C'); // a third letter is not allowed at this position
+      expect(input.value).toBe('AB');
+      type('1234'); // digits accepted
+      expect(input.value).toBe('AB1234');
+      expect(page.rootInstance.value).toBe('AB1234');
+    });
+
+    it('disables the mask and warns for an unsupported/invalid regex', async () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { input, type } = await setup('[A-Z'); // unterminated character class
+
+      type('a!1'); // mask disabled → input passes through untouched
+      expect(input.value).toBe('a!1');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('maskOptions.regex'));
+      warn.mockRestore();
+    });
+  });
+
+  describe('regex mask — interactions with other features', () => {
+    const typeInto = (input: HTMLInputElement, text: string) => {
+      for (const ch of text) {
+        input.value = input.value + ch;
+        input.dispatchEvent(new Event('input'));
+      }
+    };
+
+    it('does not create a Cleave instance for a regex-only mask', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { regex: /^[A-Z]+$/ };
+      await page.waitForChanges();
+      // cleaveInstance must stay undefined so the Cleave-specific code paths (initial
+      // space stripping, backspace delimiter logic) never run for regex masks.
+      expect((page.rootInstance as any).cleaveInstance).toBeUndefined();
+    });
+
+    it('reverts to the initial value (not empty) when the first keystroke is invalid', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text" value="ABC"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { regex: /^[A-Z]+$/ };
+      await page.waitForChanges();
+      const input = page.root.querySelector('input') as HTMLInputElement;
+
+      typeInto(input, '!'); // invalid right away
+      expect(input.value).toBe('ABC'); // restored, not wiped to ''
+    });
+
+    it('keeps a programmatically-set value as the revert target', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { regex: /^[A-Z]+$/ };
+      await page.waitForChanges();
+      const input = page.root.querySelector('input') as HTMLInputElement;
+
+      // External/programmatic value set.
+      page.rootInstance.value = 'XY';
+      await page.waitForChanges();
+      expect(input.value).toBe('XY');
+
+      typeInto(input, '!'); // invalid keystroke
+      expect(input.value).toBe('XY'); // reverts to the set value, not stale ''
+    });
+
+    it('reverts cleanly after the clear button is used', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text" clearable="true"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { regex: /^[A-Z]+$/ };
+      await page.waitForChanges();
+      const input = page.root.querySelector('input') as HTMLInputElement;
+
+      typeInto(input, 'ABC');
+      expect(input.value).toBe('ABC');
+
+      (page.rootInstance as any).handleFormReset();
+      await page.waitForChanges();
+
+      typeInto(input, '!'); // invalid after clear
+      expect(input.value).toBe(''); // empty, not the stale 'ABC'
+      typeInto(input, 'Z');
+      expect(input.value).toBe('Z');
+    });
+
+    it('salvages the valid leading prefix of a pasted value', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { regex: /^[A-Z]+$/ };
+      await page.waitForChanges();
+      const input = page.root.querySelector('input') as HTMLInputElement;
+
+      // Simulate a paste: the whole string lands at once, then one input event fires.
+      input.value = 'AB!CD';
+      input.dispatchEvent(new Event('input'));
+      expect(input.value).toBe('AB'); // leading valid prefix kept, junk dropped
+    });
+
+    it('resets revert state when the mask changes at runtime', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { regex: /^[A-Z]+$/ };
+      await page.waitForChanges();
+      const input = page.root.querySelector('input') as HTMLInputElement;
+
+      typeInto(input, 'ABC');
+      expect(input.value).toBe('ABC');
+
+      // Switch to a digits-only mask; the stale 'ABC' must not survive as a revert target.
+      page.rootInstance.maskOptions = { regex: /^[0-9]+$/ };
+      await page.waitForChanges();
+      // Field still shows ABC, but the new mask rejects it; clear and type digits.
+      input.value = '';
+      typeInto(input, '12a3');
+      expect(input.value).toBe('123');
+    });
+
+    it('does not break a regular Cleave (date) mask', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { date: true, datePattern: ['d', 'm', 'Y'], delimiter: '.' };
+      await page.waitForChanges();
+      // A Cleave instance must still be created for non-regex masks.
+      expect((page.rootInstance as any).cleaveInstance).toBeDefined();
+    });
+  });
+
+  // Mirrors how internal components (tk-datepicker, tk-select, tk-phone-input, etc.)
+  // drive tk-input, to ensure the regex changes do not regress those usages.
+  describe('consumer usage contracts', () => {
+    it('tk-datepicker style: runtime maskOptions swap keeps a Cleave instance', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      // date-only mask, like tk-datepicker default
+      page.rootInstance.maskOptions = { date: true, datePattern: ['d', 'm', 'Y'], delimiter: '.' };
+      await page.waitForChanges();
+      expect((page.rootInstance as any).cleaveInstance).toBeDefined();
+
+      // swap to datetime mask (showTimePicker), like tk-datepicker does at runtime
+      page.rootInstance.maskOptions = { blocks: [2, 2, 4, 2, 2], delimiters: ['.', '.', ' ', ':'], numericOnly: true };
+      await page.waitForChanges();
+      expect((page.rootInstance as any).cleaveInstance).toBeDefined();
+    });
+
+    it('tk-datepicker style: disabling the mask (undefined) tears down Cleave without error', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      page.rootInstance.maskOptions = { date: true, datePattern: ['d', 'm', 'Y'], delimiter: '.' };
+      await page.waitForChanges();
+      expect((page.rootInstance as any).cleaveInstance).toBeDefined();
+
+      // disableMask / range mode passes undefined
+      page.rootInstance.maskOptions = undefined;
+      await page.waitForChanges();
+      expect((page.rootInstance as any).cleaveInstance).toBeUndefined();
+    });
+
+    it('tk-select style: chips mode is unaffected by regex logic', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="chips"></tk-input>`,
+      });
+      const input = page.root.querySelector('input') as HTMLInputElement;
+      // Add a chip via Enter, like tk-select multiple mode.
+      input.value = 'apple';
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await page.waitForChanges();
+      expect(page.rootInstance.value).toEqual(['apple']);
+    });
+
+    it('tk-phone-input / tk-textarea style: plain text mode with no mask passes through', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="text"></tk-input>`,
+      });
+      const input = page.root.querySelector('input') as HTMLInputElement;
+      // No maskOptions → no Cleave, no regex; value flows through untouched.
+      expect((page.rootInstance as any).cleaveInstance).toBeUndefined();
+      input.value = 'free text 123!';
+      input.dispatchEvent(new Event('input'));
+      expect(page.rootInstance.value).toBe('free text 123!');
+    });
+
+    it('tk-color-picker style: number mode is unaffected', async () => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="number"></tk-input>`,
+      });
+      const input = page.root.querySelector('input') as HTMLInputElement;
+      input.value = '42';
+      input.dispatchEvent(new Event('input'));
+      expect(page.rootInstance.value).toBe(42);
+    });
   });
 
   it('assigns unique data-testid values to password strength lines', async () => {

--- a/packages/core/src/components/tk-input/tk-input.tsx
+++ b/packages/core/src/components/tk-input/tk-input.tsx
@@ -11,6 +11,7 @@ import { renderIcons, getIconElementProps } from '../../utils/icon-utils';
 import { getNestedValue } from '../../utils/object-utils';
 import { renderHint } from '../../utils/hint-utils';
 import { getDataTestId } from '../../utils/test-id-utils';
+import { createIncrementalMatcher, stripAnchors, FAILED, MatchState } from '../../utils/regex-mask-utils';
 
 /**
  * The TkInput component is used to capture text input from the user.
@@ -27,9 +28,15 @@ export class TkInput implements ComponentInterface {
   private nativeInput?: HTMLInputElement;
   private tabindex?: string | number;
   private uniqueId = uuidv4();
-  private cleaveInstance: Cleave;
+  private cleaveInstance?: Cleave;
   private readOnly: boolean = false;
   private editable: boolean = true;
+  /** Memoized incremental matcher for `maskOptions.regex`; null when the regex is unsupported/invalid. */
+  private regexMatcher?: ((value: string) => MatchState) | null;
+  /** Source string the current `regexMatcher` was built from, to detect regex changes. */
+  private regexMatcherSource?: string;
+  /** Last value accepted by the regex mask, used to revert a rejected keystroke. */
+  private lastRegexAcceptedValue = '';
 
   @Element() el!: HTMLTkInputElement;
 
@@ -95,11 +102,20 @@ export class TkInput implements ComponentInterface {
   @Prop() maskOptions: IInputMaskOptions;
   @Watch('maskOptions')
   protected maskOptionsChanged(newValue: IInputMaskOptions, oldValue: IInputMaskOptions) {
-    if (!isEqual(newValue, oldValue)) {
-      this.cleaveInstance?.destroy();
+    if (isEqual(newValue, oldValue) || !this.nativeInput) return;
+    this.cleaveInstance?.destroy();
+    this.cleaveInstance = undefined;
+    // Drop any memoized regex matcher so it rebuilds for the new options, and
+    // re-seed the revert target from the current field value under the new mask.
+    this.regexMatcher = undefined;
+    this.regexMatcherSource = undefined;
+    this.lastRegexAcceptedValue = '';
+    if (this.shouldUseCleave()) {
       this.cleaveInstance = new Cleave(this.nativeInput, {
         ...this.maskOptions,
       } as CleaveOptions);
+    } else {
+      this.syncRegexAcceptedValue(this.nativeInput.value);
     }
   }
 
@@ -194,6 +210,9 @@ export class TkInput implements ComponentInterface {
       } else {
         this.nativeInput.value = newValue;
       }
+      // A programmatic value bypasses keystroke handling; keep the regex revert
+      // target in sync so a later rejected keystroke restores this value.
+      this.syncRegexAcceptedValue(this.nativeInput.value);
     }
   }
 
@@ -250,10 +269,14 @@ export class TkInput implements ComponentInterface {
     if (this.mode === 'counter') {
       this.nativeInput.value = this.clampValueByLimit(this.value)?.toString() ?? '';
     }
-    if (this.mode == 'text' && this.maskOptions) {
+    if (this.shouldUseCleave()) {
       this.cleaveInstance = new Cleave(this.nativeInput, {
         ...this.maskOptions,
       } as CleaveOptions);
+    } else {
+      // Seed the regex revert target from any initial value so the first rejected
+      // keystroke restores it instead of wiping the field.
+      this.syncRegexAcceptedValue(this.nativeInput.value);
     }
   }
   componentDidUpdate(): void {
@@ -377,6 +400,72 @@ export class TkInput implements ComponentInterface {
     return !!charToCheck && (isConfiguredDelimiter || isNumericThousandsDelimiterFallback) && charToCheck !== decimalMark;
   }
 
+  /**
+   * Whether a Cleave.js instance should back the current mask. Cleave is only used
+   * for its own formatting options; a `regex` mask is handled by the incremental
+   * matcher instead, so we never build a (useless and side-effecting) Cleave
+   * instance for it.
+   */
+  private shouldUseCleave(): boolean {
+    return this.mode === 'text' && !!this.maskOptions && !this.maskOptions.regex;
+  }
+
+  /**
+   * Re-seeds `lastRegexAcceptedValue` from a value that bypassed keystroke handling
+   * (initial render, programmatic `value` set, mask change). Keeps the revert target
+   * in sync so a later rejected keystroke restores the displayed value, not a stale one.
+   */
+  private syncRegexAcceptedValue(value: unknown): void {
+    if (this.mode !== 'text' || !this.maskOptions?.regex) return;
+    const next = value == null ? '' : String(value);
+    const matcher = this.getRegexMatcher();
+    // Only adopt values the mask would accept; an invalid programmatic value should
+    // not become the revert target.
+    if (!matcher || matcher(next) !== FAILED) {
+      this.lastRegexAcceptedValue = next;
+    }
+  }
+
+  /**
+   * Picks the value to keep when `candidate` is rejected by the regex mask.
+   *
+   * Defaults to the last accepted value, which correctly handles a single bad key
+   * pressed anywhere (the valid suffix is preserved). For a paste that introduces
+   * new valid content followed by junk, it instead keeps the longest leading prefix
+   * the matcher still accepts when that prefix is longer than the last accepted value.
+   */
+  private longestAcceptedPrefix(matcher: (value: string) => MatchState, candidate: string): string {
+    let best = this.lastRegexAcceptedValue;
+    for (let end = candidate.length; end > best.length; end--) {
+      const prefix = candidate.slice(0, end);
+      if (matcher(prefix) !== FAILED) {
+        best = prefix;
+        break;
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Returns the incremental matcher for the current `maskOptions.regex`, rebuilding
+   * it only when the regex source changes. Returns null when the regex is invalid or
+   * uses syntax we cannot model (caller then skips masking and warns once).
+   */
+  private getRegexMatcher(): ((value: string) => MatchState) | null {
+    const regex = this.maskOptions?.regex;
+    if (!regex) return null;
+    const source = typeof regex === 'string' ? regex : regex.source;
+    if (this.regexMatcherSource !== source) {
+      this.regexMatcherSource = source;
+      this.regexMatcher = createIncrementalMatcher(stripAnchors(source));
+      if (!this.regexMatcher) {
+        // eslint-disable-next-line no-console
+        console.warn(`[tk-input] maskOptions.regex "${source}" is invalid or unsupported (lookarounds/back-references are not supported); the regex mask is disabled.`);
+      }
+    }
+    return this.regexMatcher ?? null;
+  }
+
   private handleInput = (ev: Event) => {
     if (this.mode != 'chips') {
       const input = ev.target as HTMLInputElement;
@@ -391,12 +480,26 @@ export class TkInput implements ComponentInterface {
       if (this.maskOptions) {
         // Custom regex mask
         if (this.maskOptions?.regex && this.mode === 'text') {
-          const regex = typeof this.maskOptions.regex === 'string' ? new RegExp(this.maskOptions.regex, 'g') : new RegExp(this.maskOptions.regex.source, 'g');
-
-          // Regex'e uyan karakterleri filtrele
-          const matches = _value.match(regex);
-          _value = matches ? matches.join('') : '';
-          input.value = _value;
+          // The regex describes the final value, so we validate the typed value
+          // incrementally: a complete match (DONE) or a valid prefix (MORE) is
+          // accepted, while an impossible value (FAILED) is rejected and the input
+          // reverts to the last accepted value — never wiping the whole field.
+          const matcher = this.getRegexMatcher();
+          if (matcher) {
+            if (matcher(_value as string) === FAILED) {
+              // The new value can't be valid. Salvage the longest prefix the matcher
+              // still accepts — this keeps "ABC" when a single bad key is typed and,
+              // on a paste like "AB!CD", keeps the leading "AB" instead of discarding
+              // everything. Falls back to the last accepted value when nothing fits.
+              _value = this.longestAcceptedPrefix(matcher, _value as string);
+              const caretPos = _value.length;
+              input.value = _value;
+              input.setSelectionRange?.(caretPos, caretPos);
+              this.lastRegexAcceptedValue = _value as string;
+            } else {
+              this.lastRegexAcceptedValue = _value as string;
+            }
+          }
         } else {
           if (this.maskOptions.letterOnly) {
             // If letterOnly option is enabled, filter out non-letters
@@ -447,13 +550,16 @@ export class TkInput implements ComponentInterface {
     } else {
       this.value = null;
     }
+    this.lastRegexAcceptedValue = '';
     this.tkChange.emit(this.value);
   }
 
   // for add chip
   private handleInputKeyDown = (e: KeyboardEvent) => {
     // --- Cleave.js maske ayırıcı karakterlerinin silinmesi için genel çözüm ---
-    if (this.maskOptions && this.cleaveInstance && this.mode == 'text' && (e.key === 'Backspace' || e.key === 'Delete')) {
+    // Regex masks have no Cleave instance and manage their own value, so this
+    // Cleave-specific delimiter handling must not run for them.
+    if (this.maskOptions && !this.maskOptions.regex && this.cleaveInstance && this.mode == 'text' && (e.key === 'Backspace' || e.key === 'Delete')) {
       const input = this.nativeInput;
       const value = input.value;
       const selectionStart = input.selectionStart;

--- a/packages/core/src/utils/regex-mask-utils.ts
+++ b/packages/core/src/utils/regex-mask-utils.ts
@@ -1,0 +1,437 @@
+/**
+ * Incremental regex matching for input masks.
+ *
+ * A regex such as `/^[A-Z]{2}[0-9]{4}$/` describes the *final* value, not the
+ * intermediate states a user types through. Validating partial input against a
+ * full-match regex is impossible with the native `RegExp` engine (e.g. `"A"` and
+ * `"1"` both fail `^[A-Z]{2}[0-9]{4}$`, but only `"1"` should be rejected).
+ *
+ * This module compiles the pattern into a small Thompson NFA and simulates it one
+ * character at a time, so it can tell whether the value so far is a complete match
+ * (`DONE`), a valid prefix that could still grow (`MORE`), or impossible (`FAILED`).
+ *
+ * Supported syntax: literals, `.`, escapes (`\d \D \w \W \s \S` and literal
+ * escapes), character classes `[...]` / `[^...]` with ranges, groups `(...)` and
+ * `(?:...)`, alternation `|`, quantifiers `* + ? {n} {n,} {n,m}`, and anchors
+ * `^ $`. Lookarounds and back-references are not supported; patterns using them
+ * (or any pattern the native `RegExp` rejects) fall back to no masking.
+ */
+
+/** The value is a complete match for the pattern. */
+export const DONE = 'DONE';
+/** The value is a valid prefix; more characters could complete it. */
+export const MORE = 'MORE';
+/** The value can never match the pattern, no matter what is appended. */
+export const FAILED = 'FAILED';
+
+export type MatchState = typeof DONE | typeof MORE | typeof FAILED;
+
+type CharTest = (ch: string) => boolean;
+
+/**
+ * Thrown when the pattern uses constructs that cannot be modeled by a finite
+ * automaton (lookarounds, back-references). Callers treat it as "disable masking".
+ */
+class UnsupportedRegexError extends Error {}
+
+interface CharNode {
+  type: 'char';
+  match: CharTest;
+}
+interface AnchorNode {
+  type: 'anchor';
+}
+interface SeqNode {
+  type: 'seq';
+  items: AstNode[];
+}
+interface AltNode {
+  type: 'alt';
+  opts: AstNode[];
+}
+interface RepNode {
+  type: 'rep';
+  node: AstNode;
+  min: number;
+  max: number;
+}
+interface OptNode {
+  type: 'opt';
+  node: AstNode;
+}
+interface StarNode {
+  type: 'star';
+  node: AstNode;
+}
+type AstNode = CharNode | AnchorNode | SeqNode | AltNode | RepNode | OptNode | StarNode;
+
+interface NfaState {
+  eps: NfaState[];
+  cons: CharTest | null;
+  to: NfaState | null;
+  accept: boolean;
+}
+
+/** Upper bound on bounded quantifiers ({n,m}); guards against state explosion. */
+const MAX_QUANTIFIER = 1000;
+
+// ── Parser: regex source → AST ──────────────────────────────────────────────
+const parse = (src: string): AstNode => {
+  let i = 0;
+  const peek = () => src[i];
+  const next = () => src[i++];
+  const eof = () => i >= src.length;
+
+  const parseAlt = (): AstNode => {
+    const opts: AstNode[] = [parseSeq()];
+    while (peek() === '|') {
+      next();
+      opts.push(parseSeq());
+    }
+    return opts.length === 1 ? opts[0] : { type: 'alt', opts };
+  };
+
+  const parseSeq = (): AstNode => {
+    const items: AstNode[] = [];
+    while (!eof() && peek() !== '|' && peek() !== ')') {
+      items.push(parseQuant());
+    }
+    return { type: 'seq', items };
+  };
+
+  const lazy = () => {
+    if (peek() === '?') next();
+  };
+
+  const parseQuant = (): AstNode => {
+    const node = parseAtom();
+    const c = peek();
+    if (c === '*') {
+      next();
+      lazy();
+      return { type: 'rep', node, min: 0, max: Infinity };
+    }
+    if (c === '+') {
+      next();
+      lazy();
+      return { type: 'rep', node, min: 1, max: Infinity };
+    }
+    if (c === '?') {
+      next();
+      lazy();
+      return { type: 'rep', node, min: 0, max: 1 };
+    }
+    if (c === '{') {
+      const save = i;
+      const m = src.slice(i).match(/^\{(\d*)(?:,(\d*))?\}/);
+      if (m) {
+        i += m[0].length;
+        lazy();
+        const min = m[1] === '' ? 0 : Number(m[1]);
+        const max = m[2] === undefined ? (m[1] === '' ? Infinity : min) : m[2] === '' ? Infinity : Number(m[2]);
+        return { type: 'rep', node, min, max };
+      }
+      i = save; // not a quantifier; treat '{' as a literal handled by parseAtom next time
+    }
+    return node;
+  };
+
+  const parseEsc = (e: string): CharNode => {
+    // Back-references (\1..\9, \k<name>) require memory of captured text and cannot
+    // be modeled by a finite automaton.
+    if (e >= '1' && e <= '9') throw new UnsupportedRegexError('back-reference is not supported');
+    if (e === 'k') throw new UnsupportedRegexError('named back-reference is not supported');
+    const classes: Record<string, CharTest> = {
+      d: ch => ch >= '0' && ch <= '9',
+      D: ch => !(ch >= '0' && ch <= '9'),
+      w: ch => /[A-Za-z0-9_]/.test(ch),
+      W: ch => !/[A-Za-z0-9_]/.test(ch),
+      s: ch => /\s/.test(ch),
+      S: ch => !/\s/.test(ch),
+    };
+    if (classes[e]) return { type: 'char', match: classes[e] };
+    const lit = ({ n: '\n', t: '\t', r: '\r' } as Record<string, string>)[e] ?? e;
+    return { type: 'char', match: ch => ch === lit };
+  };
+
+  const parseClass = (): CharNode => {
+    next(); // consume '['
+    let neg = false;
+    if (peek() === '^') {
+      neg = true;
+      next();
+    }
+    const tests: CharTest[] = [];
+    while (!eof() && peek() !== ']') {
+      let ch = next();
+      if (ch === '\\') {
+        const e = next();
+        const classes: Record<string, CharTest> = {
+          d: c => c >= '0' && c <= '9',
+          w: c => /[A-Za-z0-9_]/.test(c),
+          s: c => /\s/.test(c),
+        };
+        if (classes[e]) {
+          tests.push(classes[e]);
+          continue;
+        }
+        ch = ({ n: '\n', t: '\t', r: '\r' } as Record<string, string>)[e] ?? e;
+      }
+      if (peek() === '-' && src[i + 1] !== ']' && i + 1 < src.length) {
+        next(); // consume '-'
+        const end = next();
+        const lo = ch;
+        const hi = end;
+        tests.push(c => c >= lo && c <= hi);
+      } else {
+        const only = ch;
+        tests.push(c => c === only);
+      }
+    }
+    next(); // consume ']'
+    return {
+      type: 'char',
+      match: c => {
+        const hit = tests.some(t => t(c));
+        return neg ? !hit : hit;
+      },
+    };
+  };
+
+  const parseAtom = (): AstNode => {
+    const c = peek();
+    if (c === '(') {
+      next();
+      if (peek() === '?') {
+        const flag = src[i + 1];
+        if (flag === ':') {
+          i += 2; // non-capturing group (?:...)
+        } else if (flag === '<' && src[i + 2] !== '=' && src[i + 2] !== '!') {
+          // Named capturing group (?<name>...) — skip up to and including '>'.
+          i += 2;
+          while (!eof() && peek() !== '>') next();
+          next(); // consume '>'
+        } else {
+          // Lookahead (?=, (?!, lookbehind (?<=, (?<! — cannot be modeled by an NFA.
+          throw new UnsupportedRegexError('lookaround is not supported');
+        }
+      }
+      const inner = parseAlt();
+      next(); // consume ')'
+      return inner;
+    }
+    if (c === '[') return parseClass();
+    if (c === '^' || c === '$') {
+      next();
+      return { type: 'anchor' };
+    }
+    if (c === '.') {
+      next();
+      return { type: 'char', match: ch => ch !== '\n' };
+    }
+    if (c === '\\') {
+      next();
+      return parseEsc(next());
+    }
+    next();
+    return { type: 'char', match: ch => ch === c };
+  };
+
+  return parseAlt();
+};
+
+// ── Normalizer: expand bounded reps into explicit optional chains ───────────
+const cloneNode = (n: AstNode): AstNode => {
+  switch (n.type) {
+    case 'char':
+      return { type: 'char', match: n.match };
+    case 'anchor':
+      return { type: 'anchor' };
+    case 'seq':
+      return { type: 'seq', items: n.items.map(cloneNode) };
+    case 'alt':
+      return { type: 'alt', opts: n.opts.map(cloneNode) };
+    case 'rep':
+      return { type: 'rep', node: cloneNode(n.node), min: n.min, max: n.max };
+    case 'opt':
+      return { type: 'opt', node: cloneNode(n.node) };
+    case 'star':
+      return { type: 'star', node: cloneNode(n.node) };
+  }
+};
+
+const expand = (node: AstNode): AstNode => {
+  switch (node.type) {
+    case 'seq':
+      return { type: 'seq', items: node.items.map(expand) };
+    case 'alt':
+      return { type: 'alt', opts: node.opts.map(expand) };
+    case 'opt':
+      return { type: 'opt', node: expand(node.node) };
+    case 'star':
+      return { type: 'star', node: expand(node.node) };
+    case 'rep': {
+      const inner = expand(node.node);
+      const min = Math.min(node.min, MAX_QUANTIFIER);
+      const items: AstNode[] = [];
+      for (let k = 0; k < min; k++) items.push(cloneNode(inner));
+      if (node.max === Infinity) {
+        items.push({ type: 'star', node: cloneNode(inner) });
+      } else {
+        // (max - min) nested-optional copies: ( inner ( inner ( ... )? )? )?
+        const span = Math.min(node.max, MAX_QUANTIFIER) - min;
+        let opt: AstNode | null = null;
+        for (let k = 0; k < span; k++) {
+          const seqItems: AstNode[] = [cloneNode(inner)];
+          if (opt) seqItems.push(opt);
+          opt = { type: 'opt', node: { type: 'seq', items: seqItems } };
+        }
+        if (opt) items.push(opt);
+      }
+      return { type: 'seq', items };
+    }
+    default:
+      return node;
+  }
+};
+
+// ── Compiler: AST → Thompson NFA ────────────────────────────────────────────
+interface Fragment {
+  start: NfaState;
+  outs: ((target: NfaState) => void)[];
+}
+
+const compile = (ast: AstNode): NfaState => {
+  const mk = (): NfaState => ({ eps: [], cons: null, to: null, accept: false });
+  const patch = (outs: Fragment['outs'], t: NfaState) => outs.forEach(set => set(t));
+
+  const build = (n: AstNode): Fragment => {
+    switch (n.type) {
+      case 'char': {
+        const s = mk();
+        return {
+          start: s,
+          outs: [
+            t => {
+              s.cons = n.match;
+              s.to = t;
+            },
+          ],
+        };
+      }
+      case 'anchor': {
+        const s = mk();
+        return { start: s, outs: [t => s.eps.push(t)] };
+      }
+      case 'seq': {
+        if (!n.items.length) {
+          const s = mk();
+          return { start: s, outs: [t => s.eps.push(t)] };
+        }
+        let f = build(n.items[0]);
+        for (let k = 1; k < n.items.length; k++) {
+          const g = build(n.items[k]);
+          patch(f.outs, g.start);
+          f = { start: f.start, outs: g.outs };
+        }
+        return f;
+      }
+      case 'alt': {
+        const s = mk();
+        const outs: Fragment['outs'] = [];
+        n.opts.forEach(o => {
+          const f = build(o);
+          s.eps.push(f.start);
+          outs.push(...f.outs);
+        });
+        return { start: s, outs };
+      }
+      case 'opt': {
+        const f = build(n.node);
+        const s = mk();
+        s.eps.push(f.start);
+        return { start: s, outs: [...f.outs, t => s.eps.push(t)] };
+      }
+      case 'star': {
+        const s = mk();
+        const f = build(n.node);
+        s.eps.push(f.start);
+        patch(f.outs, s);
+        return { start: s, outs: [t => s.eps.push(t)] };
+      }
+      case 'rep': {
+        // Reps are removed by expand(); compile the equivalent star as a safety net.
+        return build({ type: 'star', node: n.node });
+      }
+    }
+  };
+
+  const f = build(ast);
+  const accept = mk();
+  accept.accept = true;
+  patch(f.outs, accept);
+  return f.start;
+};
+
+// ── Simulation ──────────────────────────────────────────────────────────────
+const epsClosure = (states: Iterable<NfaState>): Set<NfaState> => {
+  const stack = [...states];
+  const seen = new Set<NfaState>(stack);
+  while (stack.length) {
+    const s = stack.pop()!;
+    for (const t of s.eps) {
+      if (!seen.has(t)) {
+        seen.add(t);
+        stack.push(t);
+      }
+    }
+  }
+  return seen;
+};
+
+const stepStates = (states: Set<NfaState>, ch: string): Set<NfaState> => {
+  const nextStates = new Set<NfaState>();
+  for (const s of states) {
+    if (s.cons && s.to && s.cons(ch)) nextStates.add(s.to);
+  }
+  return epsClosure(nextStates);
+};
+
+/**
+ * Builds a reusable matcher for a pattern.
+ *
+ * @param source - The regex source string (anchors `^ $` are accepted and treated
+ *   as a single-line, fully-anchored match).
+ * @returns A `classify(value)` function returning {@link MatchState}, or `null` if
+ *   the pattern is unsupported/invalid (caller should skip masking in that case).
+ */
+export const createIncrementalMatcher = (source: string): ((value: string) => MatchState) | null => {
+  // Let the native engine reject malformed patterns (unterminated classes/groups,
+  // invalid escapes, lookarounds we can't model, …) so we never silently
+  // misinterpret a bad regex.
+  try {
+    // eslint-disable-next-line no-new
+    new RegExp(source);
+  } catch {
+    return null;
+  }
+
+  let start: NfaState;
+  try {
+    start = compile(expand(parse(source)));
+  } catch {
+    return null;
+  }
+
+  return (value: string): MatchState => {
+    let current = epsClosure([start]);
+    for (const ch of value) {
+      current = stepStates(current, ch);
+      if (current.size === 0) return FAILED;
+    }
+    return [...current].some(s => s.accept) ? DONE : MORE;
+  };
+};
+
+/** Strips leading `^` and trailing `$` for use where anchors are implied. */
+export const stripAnchors = (source: string): string => source.replace(/^\^/, '').replace(/\$$/, '');

--- a/packages/core/src/utils/test/regex-mask-edge.spec.ts
+++ b/packages/core/src/utils/test/regex-mask-edge.spec.ts
@@ -1,0 +1,71 @@
+import { createIncrementalMatcher, stripAnchors, DONE, MORE, FAILED, MatchState } from '../regex-mask-utils';
+
+const cl = (src: string, val: string): MatchState | 'NULL' => {
+  const m = createIncrementalMatcher(stripAnchors(src));
+  return m ? m(val) : 'NULL';
+};
+
+/**
+ * Documents the real capabilities and the known limits of the incremental matcher.
+ * The "supported" cases must pass; the "limitations" block records constructs we
+ * deliberately do not model so the behavior is explicit rather than surprising.
+ */
+describe('regex-mask-utils — capability matrix', () => {
+  describe('supported (must pass)', () => {
+    const cases: Array<[string, string, MatchState]> = [
+      // Optional groups (e.g. an optional country prefix).
+      ['^(\\+90)?[0-9]{10}$', '5551234567', DONE],
+      ['^(\\+90)?[0-9]{10}$', '+905551234567', DONE],
+      ['^(\\+90)?[0-9]{10}$', '+90', MORE],
+      // Multi-segment structured values.
+      ['^[a-z]+@[a-z]+\\.[a-z]{2,3}$', 'a@b.co', DONE],
+      ['^[a-z]+@[a-z]+\\.[a-z]{2,3}$', 'a@b.', MORE],
+      ['^[a-z]+@[a-z]+\\.[a-z]{2,3}$', 'a@b.c1', FAILED],
+      // Alternation between different lengths.
+      ['^(\\d{4}|\\d{6})$', '1234', DONE],
+      ['^(\\d{4}|\\d{6})$', '12345', MORE],
+      ['^(\\d{4}|\\d{6})$', '123456', DONE],
+      // Greedy dot with a fixed suffix.
+      ['^.*-end$', 'anything-end', DONE],
+      ['^.*-end$', 'anything-', MORE],
+      // Escaped special characters (currency).
+      ['^\\$\\d+\\.\\d{2}$', '$12.34', DONE],
+      ['^\\$\\d+\\.\\d{2}$', '$12', MORE],
+      // Non-ASCII ranges.
+      ['^[a-zçğıöşü]+$', 'çağrı', DONE],
+      // Named capturing groups behave like normal groups.
+      ['^(?<year>\\d{4})$', '2024', DONE],
+      ['^(?<year>\\d{4})$', '20', MORE],
+      // Bounded repetition of groups (common in masks).
+      ['^(ab){2,3}$', 'ab', MORE],
+      ['^(ab){2,3}$', 'abab', DONE],
+      ['^(ab){2,3}$', 'abababab', FAILED],
+      ['^([0-9]{3}){2}$', '123', MORE],
+      ['^([0-9]{3}){2}$', '123456', DONE],
+    ];
+    cases.forEach(([src, val, exp]) => {
+      it(`/${src}/ "${val}" → ${exp}`, () => {
+        expect(cl(src, val)).toBe(exp);
+      });
+    });
+  });
+
+  describe('unsupported syntax degrades to disabled mask (returns null, never crashes)', () => {
+    it('lookahead', () => expect(cl('^(?=.*\\d)[a-z]+$', 'abc1')).toBe('NULL'));
+    it('lookbehind', () => expect(cl('^(?<=\\d)[a-z]+$', '1a')).toBe('NULL'));
+    it('back-reference', () => expect(cl('^(.)\\1$', 'aa')).toBe('NULL'));
+    it('named back-reference', () => expect(cl('^(?<c>.)\\k<c>$', 'aa')).toBe('NULL'));
+    it('malformed (unterminated class)', () => expect(cl('[A-Z', 'A')).toBe('NULL'));
+  });
+
+  // KNOWN LIMITATION: an unbounded quantifier (+/*) nested directly inside a bounded
+  // quantifier ({n,m}) makes the per-repetition boundary ambiguous for our expansion
+  // strategy. Such patterns are not realistic input masks; we record the actual
+  // behavior here so it is intentional and visible, not a silent surprise.
+  describe('known limitation (documented, not a regression)', () => {
+    it('unbounded-inside-bounded is over-permissive', () => {
+      // Ideally MORE (needs >= 2 outer reps); the matcher accepts it as DONE.
+      expect(cl('^((ab)+|c){2,3}$', 'abab')).toBe(DONE);
+    });
+  });
+});

--- a/packages/core/src/utils/test/regex-mask-utils.spec.ts
+++ b/packages/core/src/utils/test/regex-mask-utils.spec.ts
@@ -1,0 +1,130 @@
+import { createIncrementalMatcher, stripAnchors, DONE, MORE, FAILED, MatchState } from '../regex-mask-utils';
+
+describe('regex-mask-utils', () => {
+  describe('createIncrementalMatcher', () => {
+    const classify = (source: string, value: string): MatchState | null => {
+      const matcher = createIncrementalMatcher(stripAnchors(source));
+      return matcher ? matcher(value) : null;
+    };
+
+    const table: Array<[string, Array<[string, MatchState]>]> = [
+      [
+        '^[A-Z]{2}[0-9]{4}$',
+        [
+          ['', MORE],
+          ['A', MORE],
+          ['AB', MORE],
+          ['AB1', MORE],
+          ['AB1234', DONE],
+          ['1', FAILED],
+          ['ABX', FAILED],
+          ['AB12345', FAILED],
+        ],
+      ],
+      [
+        '^(abc|def)$',
+        [
+          ['a', MORE],
+          ['ab', MORE],
+          ['abc', DONE],
+          ['de', MORE],
+          ['def', DONE],
+          ['x', FAILED],
+          ['abcd', FAILED],
+        ],
+      ],
+      [
+        '^[0-9,]{1,10}$',
+        [
+          ['', MORE],
+          ['1', DONE],
+          ['1,2,3', DONE],
+          ['1234567890', DONE],
+          ['1234567890,', FAILED],
+          ['1a', FAILED],
+        ],
+      ],
+      [
+        '^[A-Z]+$',
+        [
+          ['A', DONE],
+          ['ABC', DONE],
+          ['', MORE],
+          ['A1', FAILED],
+        ],
+      ],
+      [
+        '^\\d{3}-\\d{2}$',
+        [
+          ['1', MORE],
+          ['123', MORE],
+          ['123-', MORE],
+          ['123-4', MORE],
+          ['123-45', DONE],
+          ['123-456', FAILED],
+          ['12a', FAILED],
+        ],
+      ],
+      [
+        '^[a-z{}]+$',
+        [
+          ['a', DONE],
+          ['a{}', DONE],
+          ['a{}b', DONE],
+          ['A', FAILED],
+        ],
+      ],
+      [
+        '^[0-9]{0,3}$',
+        [
+          ['', DONE],
+          ['1', DONE],
+          ['123', DONE],
+          ['1234', FAILED],
+          ['a', FAILED],
+        ],
+      ],
+      [
+        '^[A-Za-z][A-Za-z0-9_]*$',
+        [
+          ['myVar_1', DONE],
+          ['1abc', FAILED],
+          ['', MORE],
+        ],
+      ],
+    ];
+
+    table.forEach(([source, cases]) => {
+      describe(source, () => {
+        cases.forEach(([value, expected]) => {
+          it(`classifies "${value}" as ${expected}`, () => {
+            expect(classify(source, value)).toBe(expected);
+          });
+        });
+      });
+    });
+
+    it('returns null for a malformed regex (unterminated class)', () => {
+      expect(createIncrementalMatcher('[A-Z')).toBeNull();
+    });
+
+    it('returns null for a malformed regex (unterminated group)', () => {
+      expect(createIncrementalMatcher('(abc')).toBeNull();
+    });
+
+    it('returns null for unsupported syntax (lookahead) gracefully or matches without crashing', () => {
+      // Lookaheads are valid regex, so the native check passes; we just must not throw.
+      const matcher = createIncrementalMatcher('(?=.*[0-9])[a-z]+');
+      expect(() => matcher && matcher('abc')).not.toThrow();
+    });
+  });
+
+  describe('stripAnchors', () => {
+    it('removes leading ^ and trailing $', () => {
+      expect(stripAnchors('^[0-9]+$')).toBe('[0-9]+');
+    });
+    it('leaves an unanchored pattern unchanged', () => {
+      expect(stripAnchors('[0-9]+')).toBe('[0-9]+');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes and substantially extends the `tk-input` `maskOptions.regex` mask.

**Original bug:** when a developer set only a `regex` in `maskOptions`, typing a character that didn't match the rule **wiped the entire field**. Root cause: the old code applied the regex with `String.match()`, which returns `null` for an anchored/full-value pattern like `/^[0-9,]{1,10}$/` the moment any invalid character is present — so the value was reset to `''`.

A full regex describes the *final* value, not the intermediate states a user types through. Validating partial input against such a pattern is impossible with the native `RegExp` engine (e.g. both `"A"` and `"1"` fail `/^[A-Z]{2}[0-9]{4}$/`, but only `"1"` should be rejected). This is a known limitation that even mature mask libraries (IMask) document.

## What changed

- New `regex-mask-utils.ts`: a small, zero-dependency **Thompson-NFA incremental matcher** that classifies a value as `DONE` (complete), `MORE` (valid prefix, keep typing) or `FAILED` (impossible). Supports the regular-language subset of JS regex: character classes/ranges, groups & nested groups, alternation, all quantifiers (`* + ? {n} {n,m}`), optional groups, named groups, anchors, and non-ASCII ranges.
- `tk-input` now validates `regex` masks incrementally: an invalid keystroke is **rejected and the field reverts** to the last valid value (caret preserved), never wiped. Length limits from quantifiers like `{1,10}` are enforced.
- **Safe degradation:** unsupported syntax (lookarounds, back-references) and malformed patterns are detected via the native `RegExp` constructor and the parser, disabling the mask with a single `console.warn` instead of throwing or silently misbehaving.

## Interaction hardening (review of the whole component)

Reviewed every feature that touches the changed surfaces and fixed several latent interaction bugs:

- No `Cleave` instance is created for **regex-only** masks (previously an inert Cleave was built, which stripped initial spaces and enabled Cleave-only backspace logic).
- The revert target stays in sync on **initial render**, **programmatic value set**, **clear/reset**, and **runtime mask change** (previously these could revert to a stale/empty value and wipe user data).
- **Paste** keeps the longest valid leading prefix instead of discarding everything; caret math fixed.
- The Cleave-specific Backspace/Delete delimiter handler is explicitly gated to non-regex masks.

## Consumers verified

`tk-input` is used internally by `tk-datepicker`, `tk-select`, `tk-phone-input`, `tk-color-picker`, `tk-pagination`, `tk-textarea`, and `tk-table`. None use `maskOptions.regex` (they use Cleave masks or none), so the regex paths are no-ops for them. Verified via: full package `tsc` (0 errors), full `stencil build` (success), and new **consumer-contract tests** that mirror how each consumer drives `tk-input` (e.g. datepicker's runtime mask swap and `disableMask` → undefined transition, select chips mode, number/plain-text modes).

## Tests

- `regex-mask-utils.spec.ts` — matcher unit tests
- `regex-mask-edge.spec.ts` — capability matrix + documented limits (lookaround/backref → disabled; one known edge: unbounded-inside-bounded quantifier)
- `tk-input.spec.tsx` — regex behavior, interaction, and consumer-contract tests

All new specs pass (99 tests across the three files); package-wide `tsc` is clean and `stencil build` succeeds.

> Note: many existing component spec suites currently fail to **load** in this environment due to `uuid@14` shipping pure ESM (unrelated to this change). Tracked separately in #547. The new specs in this PR add a local `jest.mock('uuid', …)` to work around it.

## Docs

Adds a dedicated **Regex Mask** section and `RegexMask` example (React/Vue/Angular) under the existing Mask docs, with a caveat callout for unsupported syntax.

## Changeset

Included (`@takeoff-ui/core`: minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)