### PR TITLE
docs(tk-table): Add server-side multi-sort demo

### DIFF
--- a/.changeset/table-server-side-multi-sort-demo.md
+++ b/.changeset/table-server-side-multi-sort-demo.md
@@ -1,0 +1,8 @@
+---
+'@takeoff-ui/docs': patch
+---
+
+docs(tk-table): add a server-side multi-sort example. With `multiSort` and
+`paginationMethod="server"` combined, the table emits the full `sorts` array (in
+priority order) on the `tk-request` event and skips internal sorting, so the
+backend can sort by multiple columns. No component change required.

--- a/docs/src/docs-files/tk-table/Examples/ServerSideMultiSort.tsx
+++ b/docs/src/docs-files/tk-table/Examples/ServerSideMultiSort.tsx
@@ -1,0 +1,259 @@
+import { ITableColumn, TkTableCustomEvent, ITableRequest } from '@takeoff-ui/core';
+import { TkButton, TkTable } from '@takeoff-ui/react';
+import FeatureDemo from '../../../components/FeatureDemo';
+import React, { useEffect, useRef, useState } from 'react';
+import { fetchFromServerMultiSort } from './server';
+
+const Example = () => {
+  const column: ITableColumn[] = [
+    {
+      field: 'id',
+      header: 'Id',
+    },
+    {
+      field: 'name',
+      header: 'Name',
+      searchable: true,
+      sortable: true,
+    },
+    {
+      field: 'category',
+      header: 'Category',
+      searchable: true,
+      sortable: true,
+    },
+    {
+      field: 'quantity',
+      header: 'Quantity',
+      sortable: true,
+    },
+  ];
+
+  const tableRef = useRef<HTMLTkTableElement>(null);
+  const [data, setData] = useState();
+  const [totalItem, setTotalItem] = useState();
+  const [rowsPerPage, setRowsPerPage] = useState(5);
+  const [loading, setLoading] = useState(false);
+
+  const handleRequest = async (e: TkTableCustomEvent<ITableRequest>) => {
+    setLoading(true);
+    const result: any = await fetchFromServerMultiSort(e.detail.currentPage, e.detail.rowsPerPage, e.detail.filters, e.detail.sorts);
+
+    setTotalItem(result?.totalItem);
+    setRowsPerPage(e.detail.rowsPerPage);
+    setData(result?.data);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    tableRef.current.serverRequest();
+  }, []);
+
+  return (
+    <>
+      <TkButton
+        icon="refresh"
+        variant="neutral"
+        type="text"
+        onTkClick={async () => {
+          setLoading(true);
+          const result: any = await fetchFromServerMultiSort(1, 5, [], []);
+
+          setTotalItem(result?.totalItem);
+          setData(result?.data);
+          setLoading(false);
+
+          tableRef.current!.setCurrentPage(1);
+        }}
+      />
+      <TkTable
+        ref={tableRef}
+        columns={column}
+        data={data}
+        multiSort={true}
+        paginationMethod="server"
+        rowsPerPage={rowsPerPage}
+        totalItems={totalItem}
+        loading={loading}
+        onTkRequest={handleRequest}
+      />
+    </>
+  );
+};
+
+const ServerSideMultiSort = () => {
+  const reactCode = `const column: ITableColumn[] = [
+  {
+    field: "id",
+    header: "Id",
+  },
+  {
+    field: "name",
+    header: "Name",
+    searchable: true,
+    sortable: true,
+  },
+  {
+    field: "category",
+    header: "Category",
+    searchable: true,
+    sortable: true,
+  },
+  {
+    field: "quantity",
+    header: "Quantity",
+    sortable: true,
+  },
+];
+
+const tableRef = useRef<HTMLTkTableElement>(null);
+const [data, setData] = useState();
+const [totalItem, setTotalItem] = useState();
+const [rowsPerPage, setRowsPerPage] = useState(5);
+const [loading, setLoading] = useState(false);
+
+const handleRequest = async (e: TkTableCustomEvent<ITableRequest>) => {
+  setLoading(true);
+  // The table emits the full multi-sort array in priority order.
+  // Pass it to the backend as ORDER BY col1 dir1, col2 dir2, ...
+  const result: any = await fetchFromServerMultiSort(
+    e.detail.currentPage,
+    e.detail.rowsPerPage,
+    e.detail.filters,
+    e.detail.sorts
+  );
+
+  setTotalItem(result?.totalItem);
+  setRowsPerPage(e.detail.rowsPerPage);
+  setData(result?.data);
+  setLoading(false);
+};
+
+useEffect(() => {
+  tableRef.current.serverRequest();
+}, []);
+
+return (
+  <>
+    <TkButton
+      icon="refresh"
+      variant="neutral"
+      type="text"
+      onTkClick={async () => {
+        setLoading(true);
+        const result: any = await fetchFromServerMultiSort(1, 5, [], []);
+
+        setTotalItem(result?.totalItem);
+        setData(result?.data);
+        setLoading(false);
+
+        tableRef.current!.setCurrentPage(1);
+      }}
+    />
+    <TkTable
+      ref={tableRef}
+      columns={column}
+      data={data}
+      multiSort={true}
+      paginationMethod="server"
+      rowsPerPage={rowsPerPage}
+      totalItems={totalItem}
+      loading={loading}
+      onTkRequest={handleRequest}
+    />
+  </>
+);`;
+
+  const vueCode = `<script setup>
+import { TkTable, TkButton } from '@takeoff-ui/vue'
+import { ref, onMounted } from 'vue';
+
+const column = [
+  {
+    field: "id",
+    header: "Id",
+  },
+  {
+    field: "name",
+    header: "Name",
+    searchable: true,
+    sortable: true,
+  },
+  {
+    field: "category",
+    header: "Category",
+    searchable: true,
+    sortable: true,
+  },
+  {
+    field: "quantity",
+    header: "Quantity",
+    sortable: true,
+  },
+];
+
+const tableRef = ref(null);
+const data = ref();
+const totalItem = ref();
+const rowsPerPage = ref(5);
+const loading = ref(false);
+
+const handleRequest = async (e) => {
+  loading.value = true;
+  // The table emits the full multi-sort array in priority order.
+  // Pass it to the backend as ORDER BY col1 dir1, col2 dir2, ...
+  const result = await fetchFromServerMultiSort(
+    e.detail.currentPage,
+    e.detail.rowsPerPage,
+    e.detail.filters,
+    e.detail.sorts
+  );
+
+  totalItem.value = result?.totalItem;
+  rowsPerPage.value = e.detail.rowsPerPage;
+  data.value = result?.data;
+  loading.value = false;
+};
+
+onMounted(() => {
+  tableRef.value.serverRequest();
+});
+
+const refreshData = async () => {
+  loading.value = true;
+  const result = await fetchFromServerMultiSort(1, 5, [], []);
+
+  totalItem.value = result?.totalItem;
+  data.value = result?.data;
+  loading.value = false;
+
+  tableRef.value.setCurrentPage(1);
+};
+</script>
+
+<template>
+  <TkButton
+    icon="refresh"
+    variant="neutral"
+    type="text"
+    @tkClick="refreshData"
+  />
+  <TkTable
+    ref="tableRef"
+    :columns="column"
+    :data="data"
+    :multiSort="true"
+    paginationMethod="server"
+    :rowsPerPage="rowsPerPage"
+    :totalItems="totalItem"
+    :loading="loading"
+    @tkRequest="handleRequest"
+  />
+</template>
+`;
+
+  const demo = <Example />;
+  return <FeatureDemo demo={demo} reactCode={reactCode} vueCode={vueCode} angularCode={''}></FeatureDemo>;
+};
+
+export default ServerSideMultiSort;

--- a/docs/src/docs-files/tk-table/Examples/server.ts
+++ b/docs/src/docs-files/tk-table/Examples/server.ts
@@ -26,4 +26,35 @@ const fetchFromServer = async (page: number, rowsPerPage: number, filters: any[]
   });
 };
 
+// Multi-sort aware variant. The table emits a `sorts` array (in priority order)
+// on the tk-request event; here we replicate what a backend would do with an
+// `ORDER BY col1 dir1, col2 dir2, ...` clause.
+export const fetchFromServerMultiSort = async (page: number, rowsPerPage: number, filters: any[], sorts: { field: string; order: string }[]) => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      let newPageData;
+      let totalItem;
+      newPageData = [...data].filter(row => filters.every(filter => row[filter.field].toString().toLowerCase().indexOf(filter.value.toLowerCase()) > -1));
+
+      if (sorts?.length > 0) {
+        newPageData = newPageData.sort((a, b) => {
+          for (const sort of sorts) {
+            if (a[sort.field] === b[sort.field]) continue;
+            const result = a[sort.field] > b[sort.field] ? 1 : -1;
+            return sort.order === 'asc' ? result : -result;
+          }
+          return 0;
+        });
+      }
+      totalItem = newPageData.length;
+
+      const startIndex = (page - 1) * rowsPerPage;
+      const endIndex = startIndex + rowsPerPage;
+      newPageData = newPageData.slice(startIndex, endIndex);
+
+      resolve({ data: newPageData, totalItem: totalItem });
+    }, 1500);
+  });
+};
+
 export default fetchFromServer;

--- a/docs/src/docs-files/tk-table/body.mdx
+++ b/docs/src/docs-files/tk-table/body.mdx
@@ -8,6 +8,7 @@ import FilterAndSort from './Examples/FilterAndSort';
 import Pagination from './Examples/Pagination';
 import Localization from './Examples/Localization';
 import ServerSide from './Examples/ServerSide';
+import ServerSideMultiSort from './Examples/ServerSideMultiSort';
 import CustomCell from './Examples/CustomCell';
 import RowCellStyle from './Examples/RowCellStyle';
 import ExpandedRows from './Examples/ExpandedRows';
@@ -126,6 +127,17 @@ Customize pagination labels for different locales using `pageReportTemplate` and
 Server side sorting, filter ang pagination example.
 
 <ServerSide />
+
+## Server Side Multi Sorting
+
+Server side multi-column sorting. With `multiSort` and
+`paginationMethod="server"` together, the table does not sort internally — it
+emits the full `sorts` array (in priority order) on the `tk-request` event. The
+consumer forwards it to the backend, which sorts as
+`ORDER BY col1 dir1, col2 dir2, ...`. Click multiple headers to build up the
+sort order.
+
+<ServerSideMultiSort />
 
 ## Custom Cell
 


### PR DESCRIPTION
## Summary

Adds a **server-side multi-sort** example for `TkTable`, complementing the existing client-side `MultiSort` demo and the single-column `ServerSide` demo.

Key point: the Table component **already supports this** — when `multiSort` and `paginationMethod="server"` are combined, the table does not sort internally and emits the full `sorts` array (in priority order) on the `tk-request` event. So **no component change was needed** — only a demo and a multi-sort-aware mock backend were missing.

## Changes

- **`Examples/server.ts`** — adds `fetchFromServerMultiSort`, which sorts by the `sorts` array in priority order (mimics a backend `ORDER BY col1 dir1, col2 dir2, ...`). The existing single-sort `fetchFromServer` is left untouched.
- **`Examples/ServerSideMultiSort.tsx`** — new demo combining `multiSort={true}` with `paginationMethod="server"`, forwarding `e.detail.sorts` to the backend. Includes React + Vue code snippets.
- **`tk-table/body.mdx`** — registers the demo under a new **"Server Side Multi Sorting"** section, right after the existing Server Side demo.

## Verification

- `tsc --noEmit` on the docs package: no type errors in the changed files (only pre-existing, unrelated errors in `tk-datepicker` / `tk-gantt-chart`).
- `e.detail.sorts` is typed `ITableSort[]` (`{ field, order: 'asc' | 'desc' }`), matching the new server function signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)