### PR TITLE
Fix editor tk-change not firing after external value update

### DIFF
--- a/.changeset/fix-editor-external-update.md
+++ b/.changeset/fix-editor-external-update.md
@@ -1,0 +1,6 @@
+---
+'@takeoff-ui/core': patch
+---
+
+Fix Editor swallowing the first user edit after an external value update by
+emitting Tiptap's update event on programmatic `setContent`.

--- a/packages/core/src/components/tk-editor/test/tk-editor.spec.tsx
+++ b/packages/core/src/components/tk-editor/test/tk-editor.spec.tsx
@@ -1,23 +1,33 @@
 jest.mock('@tiptap/core', () => ({
-  Editor: jest
-    .fn()
-    .mockImplementation(
-      (options: { content?: string; onCreate?: (payload: { editor: { getText: () => string; storage: { characterCount: { characters: () => number } } } }) => void }) => {
-        options.onCreate?.({ editor: { getText: () => '', storage: { characterCount: { characters: () => 0 } } } });
-        return {
-          getHTML: () => options.content || '',
-          getJSON: () => ({}),
-          getText: () => '',
-          setEditable: jest.fn(),
-          destroy: jest.fn(),
-          commands: { setContent: jest.fn() },
-          storage: { characterCount: { characters: () => 0 } },
-          isActive: jest.fn(() => false),
-          getAttributes: jest.fn(() => ({})),
-          can: jest.fn(() => ({ undo: jest.fn(() => false), redo: jest.fn(() => false) })),
-        };
+  Editor: jest.fn().mockImplementation((options: { content?: string; onCreate?: (payload: { editor: unknown }) => void; onUpdate?: (payload: { editor: unknown }) => void }) => {
+    let html = options.content || '';
+    const instance = {
+      getHTML: () => html,
+      getJSON: () => ({}),
+      getText: () => '',
+      setEditable: jest.fn(),
+      destroy: jest.fn(),
+      commands: {
+        // mirrors Tiptap v2: onUpdate fires only when emitUpdate is true
+        setContent: jest.fn((content: string, emitUpdate?: boolean) => {
+          html = content;
+          if (emitUpdate) {
+            options.onUpdate?.({ editor: instance });
+          }
+        }),
       },
-    ),
+      storage: { characterCount: { characters: () => 0 } },
+      isActive: jest.fn(() => false),
+      getAttributes: jest.fn(() => ({})),
+      can: jest.fn(() => ({ undo: jest.fn(() => false), redo: jest.fn(() => false) })),
+      __setHtml: (next: string) => {
+        html = next;
+      },
+      __options: options,
+    };
+    options.onCreate?.({ editor: instance });
+    return instance;
+  }),
 }));
 
 jest.mock('@tiptap/extension-placeholder', () => ({ __esModule: true, default: { configure: jest.fn(() => ({ name: 'placeholder' })) } }));
@@ -29,9 +39,14 @@ jest.mock('@tiptap/extension-link', () => ({ __esModule: true, default: { config
 jest.mock('@tiptap/extension-image', () => ({ __esModule: true, default: { configure: jest.fn(() => ({ name: 'image' })) } }));
 
 import { newSpecPage } from '@stencil/core/testing';
+import { Editor } from '@tiptap/core';
 import { TkEditor } from '../tk-editor';
 
 describe('tk-editor', () => {
+  beforeEach(() => {
+    (Editor as unknown as jest.Mock).mockClear();
+  });
+
   it('hides the toolbar when hideToolbar is enabled', async () => {
     const page = await newSpecPage({
       components: [TkEditor],
@@ -39,5 +54,27 @@ describe('tk-editor', () => {
     });
 
     expect(page.root.querySelector('.tk-editor-toolbar')).toBeNull();
+  });
+
+  it('does not emit tk-change for an external value update but emits for the next user edit', async () => {
+    const page = await newSpecPage({
+      components: [TkEditor],
+      html: `<tk-editor></tk-editor>`,
+    });
+    const editorMock = (Editor as unknown as jest.Mock).mock.results[0].value;
+    const onTkChange = jest.fn();
+    page.root.addEventListener('tk-change', onTkChange);
+
+    // parent sets the value programmatically (e.g. reverting after a length guard)
+    (page.root as HTMLTkEditorElement).value = '<p>reverted</p>';
+    await page.waitForChanges();
+    expect(editorMock.commands.setContent).toHaveBeenCalledWith('<p>reverted</p>', true);
+    expect(onTkChange).not.toHaveBeenCalled();
+
+    // the next real user edit fires Tiptap's onUpdate and must not be swallowed
+    editorMock.__setHtml('<p><strong>reverted</strong></p>');
+    editorMock.__options.onUpdate({ editor: editorMock });
+    expect(onTkChange).toHaveBeenCalledTimes(1);
+    expect(onTkChange.mock.calls[0][0].detail).toBe('<p><strong>reverted</strong></p>');
   });
 });

--- a/packages/core/src/components/tk-editor/tk-editor.tsx
+++ b/packages/core/src/components/tk-editor/tk-editor.tsx
@@ -53,7 +53,9 @@ export class TkEditor {
   valueChanged(newValue: string) {
     if (this.editor && newValue !== this.editor.getHTML()) {
       this.isExternalUpdate = true;
-      this.editor.commands.setContent(newValue);
+      // emitUpdate must be true; otherwise onUpdate never fires and the flag
+      // stays armed, swallowing the next real user edit's tk-change
+      this.editor.commands.setContent(newValue, true);
     }
   }
 


### PR DESCRIPTION
Tiptap's `setContent` does not emit an update event by default, so the `isExternalUpdate` flag stayed armed after an external value update and swallowed the next user edit's `tk-change`. Passing `emitUpdate: true` lets the programmatic update consume the flag itself; external updates still emit no `tk-change`. Includes a regression spec.