### PR TITLE
Add backspace remove feature to input chips

### DIFF
--- a/.changeset/chips-keyboard-focus.md
+++ b/.changeset/chips-keyboard-focus.md
@@ -1,0 +1,15 @@
+---
+'@takeoff-ui/core': patch
+---
+
+Add keyboard handling for the chips of `tk-input`: the arrow keys walk the chips
+next to the text field, and Backspace or Delete removes the one they land on.
+Out of an empty text field the first Backspace only aims at the last chip, so no
+chip is ever removed before it has been pointed at. Chips that carry no remove
+button are stepped over, which covers disabled ones as well as indicator chips
+such as the `+2` of a collapsed `tk-select`.
+
+`tk-chips` gained a `focused` prop for this, drawing the same ring its pressed
+state uses. In `tk-select` the keys reach the selection through the chip removal
+path that was already there, so an `editable` `multiple` select can now be
+emptied from the keyboard.

--- a/packages/core/src/components/tk-chips/tk-chips.scss
+++ b/packages/core/src/components/tk-chips/tk-chips.scss
@@ -26,6 +26,14 @@
     user-select: none;
   }
 
+  &.focused {
+    box-shadow: var(--secondary-focus);
+
+    &.primary {
+      box-shadow: var(--primary-focus);
+    }
+  }
+
   &.disabled {
     color: var(--text-sub-base) !important;
     background-color: var(--frames-light) !important;

--- a/packages/core/src/components/tk-chips/tk-chips.tsx
+++ b/packages/core/src/components/tk-chips/tk-chips.tsx
@@ -89,6 +89,12 @@ export class TkChips implements ComponentInterface {
   @Prop() fullWidth: boolean = false;
 
   /**
+   * Marks the chip as the one holding the keyboard inside a chips input, e.g. while the arrow keys walk them.
+   * @defaultValue false
+   */
+  @Prop({ reflect: true }) focused: boolean = false;
+
+  /**
    * Sets the data-testid attribute on the root container element.
    */
   @Prop({ reflect: true }) dataTestid?: string;
@@ -118,6 +124,7 @@ export class TkChips implements ComponentInterface {
     const rootClasses = classNames('tk-chips', this.variant, this.size, this.type, {
       removable: this.removable,
       disabled: this.disabled,
+      focused: this.focused,
     });
     const { leftIcon, rightIcon } = renderIcons(
       this.icon,

--- a/packages/core/src/components/tk-input/test/tk-input.spec.tsx
+++ b/packages/core/src/components/tk-input/test/tk-input.spec.tsx
@@ -8,6 +8,7 @@ jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
 
 import { newSpecPage } from '@stencil/core/testing';
 import { TkInput } from '../tk-input';
+import { TkChips } from '../../tk-chips/tk-chips';
 
 describe('tk-input', () => {
   it('renders the label asterisk when showAsterisk is true', async () => {
@@ -331,6 +332,251 @@ describe('tk-input', () => {
       input.value = '42';
       input.dispatchEvent(new Event('input'));
       expect(page.rootInstance.value).toBe(42);
+    });
+  });
+
+  describe('chips mode keyboard focus', () => {
+    const createChipsInput = async (attrs = '', value: any[] = ['Alpha', 'Beta', 'Gamma'], props: Record<string, any> = {}) => {
+      const page = await newSpecPage({
+        components: [TkInput],
+        html: `<tk-input mode="chips" ${attrs}></tk-input>`,
+      });
+      Object.assign(page.root, props);
+      page.root.value = value;
+      await page.waitForChanges();
+      return page;
+    };
+
+    const nativeInputOf = (page: any) => page.root.querySelector('input') as HTMLInputElement;
+
+    const pressKey = async (page: any, key: string) => {
+      nativeInputOf(page).dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      await page.waitForChanges();
+    };
+
+    const typeInto = async (page: any, text: string) => {
+      const nativeInput = nativeInputOf(page);
+      nativeInput.value = text;
+      nativeInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await page.waitForChanges();
+    };
+
+    it('walks the focus through the chips and back into the text', async () => {
+      const page = await createChipsInput();
+
+      // ArrowRight from the text does nothing: the chips are behind it, not ahead of it
+      await pressKey(page, 'ArrowRight');
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+
+      await pressKey(page, 'ArrowLeft');
+      expect(page.rootInstance.focusedChipIndex).toBe(2);
+
+      await pressKey(page, 'ArrowLeft');
+      await pressKey(page, 'ArrowLeft');
+      expect(page.rootInstance.focusedChipIndex).toBe(0);
+
+      // the first chip is the end of the road
+      await pressKey(page, 'ArrowLeft');
+      expect(page.rootInstance.focusedChipIndex).toBe(0);
+
+      await pressKey(page, 'ArrowRight');
+      await pressKey(page, 'ArrowRight');
+      await pressKey(page, 'ArrowRight');
+      // past the last chip the text field owns the keyboard again
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+    });
+
+    it('marks the focused chip and stops the text caret from blinking behind it', async () => {
+      const page = await newSpecPage({
+        components: [TkInput, TkChips],
+        html: `<tk-input mode="chips"></tk-input>`,
+      });
+      page.root.value = ['Alpha', 'Beta', 'Gamma'];
+      await page.waitForChanges();
+
+      // which chip carries the ring, by its position among the rendered chips
+      const focusedPositions = () =>
+        Array.from(page.root.querySelectorAll('tk-chips'))
+          .map((chip: any, index) => (chip.focused ? index : -1))
+          .filter(index => index >= 0);
+
+      expect(focusedPositions()).toEqual([]);
+
+      await pressKey(page, 'ArrowLeft');
+      expect(focusedPositions()).toEqual([2]);
+      expect(page.root.querySelector('.tk-input-container').classList.contains('chips-focus-active')).toBe(true);
+
+      await pressKey(page, 'ArrowLeft');
+      expect(focusedPositions()).toEqual([1]);
+
+      await pressKey(page, 'ArrowRight');
+      await pressKey(page, 'ArrowRight');
+      expect(focusedPositions()).toEqual([]);
+      expect(page.root.querySelector('.tk-input-container').classList.contains('chips-focus-active')).toBe(false);
+    });
+
+    it('removes the focused chip, Backspace stepping back and Delete staying put', async () => {
+      const page = await createChipsInput();
+      const changes: any[] = [];
+      page.root.addEventListener('tk-change', (e: Event) => changes.push((e as CustomEvent).detail));
+
+      await pressKey(page, 'ArrowLeft');
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual(['Alpha', 'Beta']);
+      // Backspace stepped back onto the chip before the one it removed
+      expect(page.rootInstance.focusedChipIndex).toBe(1);
+
+      await pressKey(page, 'ArrowLeft');
+      await pressKey(page, 'Delete');
+      expect(page.root.value).toEqual(['Beta']);
+      // Delete stayed put and took over the chip that slid into the freed slot
+      expect(page.rootInstance.focusedChipIndex).toBe(0);
+
+      await pressKey(page, 'Delete');
+      expect(page.root.value).toEqual([]);
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+      expect(changes).toEqual([['Alpha', 'Beta'], ['Beta'], []]);
+    });
+
+    it('aims at the last chip before removing anything from the text field', async () => {
+      const page = await createChipsInput();
+
+      await typeInto(page, 'De');
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual(['Alpha', 'Beta', 'Gamma']);
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+
+      // Delete never reaches the chips from the text field, they are behind it
+      await typeInto(page, '');
+      await pressKey(page, 'Delete');
+      expect(page.root.value).toEqual(['Alpha', 'Beta', 'Gamma']);
+
+      // the first Backspace out of the empty text only focuses the last chip
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual(['Alpha', 'Beta', 'Gamma']);
+      expect(page.rootInstance.focusedChipIndex).toBe(2);
+
+      // from there each press removes one chip and steps back onto the one before it
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual(['Alpha', 'Beta']);
+      await pressKey(page, 'Backspace');
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual([]);
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+    });
+
+    it('steps over chips that carry no remove button', async () => {
+      const page = await createChipsInput('', ['Alpha', 'Beta'], { chipDisabled: (item: any) => item === 'Beta' });
+
+      // the disabled chip cannot be focused, so the walk lands on the one before it
+      await pressKey(page, 'ArrowLeft');
+      expect(page.rootInstance.focusedChipIndex).toBe(0);
+
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual(['Beta']);
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+
+      // nothing removable is left, so the keys go back to the text field
+      await pressKey(page, 'ArrowLeft');
+      await pressKey(page, 'Backspace');
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual(['Beta']);
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+
+      const indicator = { label: '+2', removable: false };
+      const collapsed = await createChipsInput('', ['Alpha', indicator]);
+      // the indicator cannot be aimed at, so both the walk and a plain Backspace land on "Alpha"
+      await pressKey(collapsed, 'Backspace');
+      expect(collapsed.rootInstance.focusedChipIndex).toBe(0);
+      await pressKey(collapsed, 'Backspace');
+      expect(collapsed.root.value).toEqual([indicator]);
+    });
+
+    it('stays out of readonly and disabled inputs, and out of text mode', async () => {
+      const readonly = await createChipsInput('readonly="true"');
+      await pressKey(readonly, 'ArrowLeft');
+      await pressKey(readonly, 'Backspace');
+      expect(readonly.rootInstance.focusedChipIndex).toBeNull();
+      expect(readonly.root.value).toEqual(['Alpha', 'Beta', 'Gamma']);
+
+      const disabled = await createChipsInput('disabled="true"');
+      await pressKey(disabled, 'ArrowLeft');
+      await pressKey(disabled, 'Backspace');
+      expect(disabled.rootInstance.focusedChipIndex).toBeNull();
+      expect(disabled.root.value).toEqual(['Alpha', 'Beta', 'Gamma']);
+
+      const text = await newSpecPage({ components: [TkInput], html: `<tk-input value="Alpha"></tk-input>` });
+      await pressKey(text, 'ArrowLeft');
+      expect(text.rootInstance.focusedChipIndex).toBeNull();
+    });
+
+    it('drops the focus when the value is replaced from the outside', async () => {
+      const page = await createChipsInput();
+
+      await pressKey(page, 'ArrowLeft');
+      expect(page.rootInstance.focusedChipIndex).toBe(2);
+
+      page.root.value = ['Alpha'];
+      await page.waitForChanges();
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+
+      // the keys work against the new list right away instead of swallowing a press
+      await pressKey(page, 'Backspace');
+      expect(page.rootInstance.focusedChipIndex).toBe(0);
+      await pressKey(page, 'Backspace');
+      expect(page.root.value).toEqual([]);
+    });
+
+    it('ignores a chips input that was handed a plain string value', async () => {
+      const page = await newSpecPage({ components: [TkInput], html: `<tk-input mode="chips" value="Alpha"></tk-input>` });
+
+      await pressKey(page, 'ArrowLeft');
+      await pressKey(page, 'Backspace');
+
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+      expect(page.root.value).toBe('Alpha');
+    });
+
+    it('leaves the arrows to a selected range in the text field', async () => {
+      const page = await createChipsInput();
+      const nativeInput = nativeInputOf(page);
+
+      await typeInto(page, 'Delta');
+      // the whole text is selected, the way Ctrl+A leaves it: the arrows still belong to the text
+      nativeInput.selectionStart = 0;
+      nativeInput.selectionEnd = 5;
+      await pressKey(page, 'ArrowLeft');
+
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+    });
+
+    it('drops the ring when the last removable chip becomes untouchable', async () => {
+      const page = await createChipsInput('', ['Alpha', 'Beta']);
+
+      await pressKey(page, 'ArrowLeft');
+      expect(page.rootInstance.focusedChipIndex).toBe(1);
+
+      page.root.chipDisabled = () => true;
+      await page.waitForChanges();
+
+      // with nothing left to remove the key goes back to the text field and the ring goes away
+      await pressKey(page, 'Backspace');
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+      expect(page.root.value).toEqual(['Alpha', 'Beta']);
+      expect(page.root.querySelector('.tk-input-container').classList.contains('chips-focus-active')).toBe(false);
+    });
+
+    it('hands the keyboard back on any other key and on blur', async () => {
+      const page = await createChipsInput();
+
+      await pressKey(page, 'ArrowLeft');
+      await pressKey(page, 'a');
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
+
+      await pressKey(page, 'ArrowLeft');
+      nativeInputOf(page).dispatchEvent(new Event('blur'));
+      await page.waitForChanges();
+      expect(page.rootInstance.focusedChipIndex).toBeNull();
     });
   });
 

--- a/packages/core/src/components/tk-input/tk-input.scss
+++ b/packages/core/src/components/tk-input/tk-input.scss
@@ -266,4 +266,10 @@ tk-input.tk-table-input {
       }
     }
   }
+
+  &.chips-focus-active {
+    .tk-input input {
+      caret-color: transparent;
+    }
+  }
 }

--- a/packages/core/src/components/tk-input/tk-input.tsx
+++ b/packages/core/src/components/tk-input/tk-input.tsx
@@ -49,6 +49,9 @@ export class TkInput implements ComponentInterface {
   @State() isPassword = false;
   @State() passwordStrength: number = 0;
   @State() hasLabelSlot: boolean = false;
+  // The chip the keyboard is aimed at, set by the arrow keys or by Backspace out of an empty text
+  // field, and null while the text field itself owns the keyboard.
+  @State() focusedChipIndex: number | null = null;
 
   /**
    * the user cannot interact with the input.
@@ -206,16 +209,23 @@ export class TkInput implements ComponentInterface {
   @Prop({ mutable: true }) value?: string | string[] | number | any[];
   @Watch('value')
   protected valueChanged(newValue, oldValue) {
-    if (!isEqual(newValue, oldValue) && this.mode !== 'chips') {
-      if (typeof newValue === 'object' && typeof oldValue === 'object') {
-        this.nativeInput.value = getNestedValue(newValue, this.chipLabelKey);
-      } else {
-        this.nativeInput.value = newValue;
-      }
-      // A programmatic value bypasses keystroke handling; keep the regex revert
-      // target in sync so a later rejected keystroke restores this value.
-      this.syncRegexAcceptedValue(this.nativeInput.value);
+    if (isEqual(newValue, oldValue)) return;
+
+    if (this.mode === 'chips') {
+      // An index into the previous chip list means nothing once that list changed. Removing a chip
+      // re-aims the focus itself, right after it has updated the value.
+      this.focusedChipIndex = null;
+      return;
     }
+
+    if (typeof newValue === 'object' && typeof oldValue === 'object') {
+      this.nativeInput.value = getNestedValue(newValue, this.chipLabelKey);
+    } else {
+      this.nativeInput.value = newValue;
+    }
+    // A programmatic value bypasses keystroke handling; keep the regex revert
+    // target in sync so a later rejected keystroke restores this value.
+    this.syncRegexAcceptedValue(this.nativeInput.value);
   }
 
   /**
@@ -544,6 +554,7 @@ export class TkInput implements ComponentInterface {
 
   private handleInputBlur = () => {
     this.hasFocus = false;
+    this.focusedChipIndex = null;
     this.validateMinMax();
     this.tkBlur.emit();
   };
@@ -610,6 +621,23 @@ export class TkInput implements ComponentInterface {
         }
       }
     }
+    if (this.mode === 'chips' && !e.isComposing) {
+      // Any key other than the ones driving the chip focus hands the keyboard back to the text field.
+      if (this.focusedChipIndex !== null && !['ArrowLeft', 'ArrowRight', 'Backspace', 'Delete'].includes(e.key)) {
+        this.focusedChipIndex = null;
+      }
+
+      if ((e.key === 'ArrowLeft' || e.key === 'ArrowRight') && this.moveChipFocus(e.key === 'ArrowLeft' ? 'left' : 'right')) {
+        e.preventDefault();
+        return;
+      }
+
+      if ((e.key === 'Backspace' || e.key === 'Delete') && this.handleChipDeleteKey(e.key === 'Backspace' ? 'backward' : 'forward')) {
+        e.preventDefault();
+        return;
+      }
+    }
+
     if (
       e.key == 'Enter' &&
       this.nativeInput.value.trim() &&
@@ -740,18 +768,104 @@ export class TkInput implements ComponentInterface {
     return lines;
   }
 
+  // A chip carries a remove button only when it may actually go, so the keyboard uses the same rule.
+  private isChipRemovable(item: any): boolean {
+    if (this.chipDisabled?.(item) || this.disabled) return false;
+    if (typeof item === 'object' && item !== null && item.hasOwnProperty('removable')) return item.removable;
+    return true;
+  }
+
+  // The chips can be walked wherever the text field itself takes input.
+  private isChipFocusNavigable(): boolean {
+    // A chips input can still be handed a plain string value, which has a length but no chips.
+    return this.mode === 'chips' && this.editable && !this.disabled && !this.readOnly && Array.isArray(this.value) && this.value.length > 0;
+  }
+
+  // A chip that cannot be removed is a dead end for the keyboard, so the walk steps over it - that
+  // covers disabled chips as well as indicator chips like the "+2 others" one.
+  private focusableChipIndexes(): number[] {
+    const focusable: number[] = [];
+    ((this.value as any[]) ?? []).forEach((item, index) => {
+      if (this.isChipRemovable(item)) focusable.push(index);
+    });
+    return focusable;
+  }
+
+  // Returns true when the key belonged to the chips, false when the text field should keep it.
+  private moveChipFocus(direction: 'left' | 'right'): boolean {
+    if (!this.isChipFocusNavigable()) return false;
+
+    const focusable = this.focusableChipIndexes();
+    if (focusable.length === 0) {
+      this.focusedChipIndex = null;
+      return false;
+    }
+
+    if (this.focusedChipIndex === null) {
+      // The chips sit before the text, so they are only entered by walking left out of its start.
+      if (direction === 'right') return false;
+      // Any caret position or selection other than a collapsed one at the very start is still text.
+      if (this.nativeInput?.value && (this.nativeInput.selectionStart !== 0 || this.nativeInput.selectionEnd !== 0)) return false;
+      this.focusedChipIndex = focusable[focusable.length - 1];
+      return true;
+    }
+
+    const position = focusable.indexOf(this.focusedChipIndex);
+    if (position === -1) {
+      // The focused chip is gone (the value changed underneath): restart from the edge.
+      this.focusedChipIndex = direction === 'left' ? focusable[focusable.length - 1] : null;
+      return true;
+    }
+
+    const next = direction === 'left' ? position - 1 : position + 1;
+    // The first chip is the end of the road; past the last one the text field takes over again.
+    if (next < 0) return true;
+    this.focusedChipIndex = next >= focusable.length ? null : focusable[next];
+    return true;
+  }
+
+  // Backspace and Delete both remove the focused chip and differ only in where they leave the
+  // focus. Nothing is ever removed unfocused: out of an empty text field the first Backspace only
+  // aims at the last chip, and the presses after it walk backwards removing one chip each.
+  private handleChipDeleteKey(direction: 'backward' | 'forward'): boolean {
+    if (!this.isChipFocusNavigable()) return false;
+
+    const focusable = this.focusableChipIndexes();
+    if (focusable.length === 0) {
+      // Nothing can be removed any more, so the ring must not stay drawn over the text field.
+      this.focusedChipIndex = null;
+      return false;
+    }
+
+    if (this.focusedChipIndex === null) {
+      // The text keeps both keys until it is empty: Delete has characters ahead of it, Backspace behind.
+      if (direction === 'forward' || this.nativeInput?.value) return false;
+      this.focusedChipIndex = focusable[focusable.length - 1];
+      return true;
+    }
+
+    const removedIndex = this.focusedChipIndex;
+    if (!focusable.includes(removedIndex)) {
+      this.focusedChipIndex = null;
+      return true;
+    }
+    this.handleChipsRemove(removedIndex);
+
+    const remaining = this.focusableChipIndexes();
+    const behind = remaining.filter(index => index < removedIndex).reverse();
+    const ahead = remaining.filter(index => index >= removedIndex);
+    // Backspace steps back onto the chip before the one it removed, Delete stays put and takes
+    // over whatever slid into the freed slot.
+    const preferred = direction === 'backward' ? [...behind, ...ahead] : [...ahead, ...behind];
+    this.focusedChipIndex = preferred.length > 0 ? preferred[0] : null;
+    return true;
+  }
+
   private renderChips() {
     if (this.mode == 'chips' && typeof this.value == 'object' && (this.value as any[])?.length > 0) {
       return (this.value as any[]).map((item, index) => {
         const itemChipOptions = this.chipOptions || {};
-        let isRemovable;
-        if (this.chipDisabled?.(item) || this.disabled) {
-          isRemovable = false;
-        } else if (typeof item === 'object' && item !== null && item.hasOwnProperty('removable')) {
-          isRemovable = item.removable;
-        } else {
-          isRemovable = true;
-        }
+        const isRemovable = this.isChipRemovable(item);
         const baseProps = {
           ...itemChipOptions,
           removable: isRemovable,
@@ -762,6 +876,7 @@ export class TkInput implements ComponentInterface {
           type: (itemChipOptions.type ?? 'outlined') as IChipOptions['type'],
           size: (itemChipOptions.size ?? 'small') as IChipOptions['size'],
           disabled: this.disabled,
+          focused: this.focusedChipIndex === index,
         };
         const isIndicator = typeof item === 'object' && item !== null && (item.__isOthersIndicator || item.__isAllIndicator);
         const label = isIndicator ? item.label : typeof item === 'object' ? getNestedValue(item, this.chipLabelKey) : String(item);
@@ -903,7 +1018,13 @@ export class TkInput implements ComponentInterface {
       );
     }
 
-    const rootClasses = classNames('tk-input-container', this.size, { focus: this.hasFocus, counter: this.isCounter, chips: this.mode == 'chips' });
+    const rootClasses = classNames('tk-input-container', this.size, {
+      'focus': this.hasFocus,
+      'counter': this.isCounter,
+      'chips': this.mode == 'chips',
+      // While a chip holds the keyboard the text field must not blink a caret of its own.
+      'chips-focus-active': this.mode == 'chips' && this.focusedChipIndex != null,
+    });
     const prefixClass = classNames('tk-input-prefix-container', this.size);
 
     // Handle icon rendering using utility function
@@ -926,7 +1047,7 @@ export class TkInput implements ComponentInterface {
     return (
       <div aria-readonly={this.readonly} aria-disabled={this.disabled} aria-invalid={this.invalid} class={rootClasses} data-testid={getDataTestId(this.dataTestid, 'container')}>
         {this.renderLabel()}
-        <div class="tk-input" data-testid={getDataTestId(this.dataTestid, 'control')}>
+        <div class="tk-input" onMouseDown={() => (this.focusedChipIndex = null)} data-testid={getDataTestId(this.dataTestid, 'control')}>
           {this.renderChips()}
           {!_leftIcon && this.renderPasswordIcons().left}
           {_leftIcon}

--- a/packages/core/src/components/tk-select/test/tk-select.spec.tsx
+++ b/packages/core/src/components/tk-select/test/tk-select.spec.tsx
@@ -792,6 +792,141 @@ describe('tk-select', () => {
 
       expect(page.root.value).toEqual(['Alpha']);
     });
+
+    describe('chip keyboard focus and removal', () => {
+      // the chip focus lives in tk-input, so these drive real key events instead of the select's handler
+      const typeInto = (page: SpecPage, text: string) => {
+        const nativeInput = page.root.querySelector('input') as HTMLInputElement;
+        nativeInput.value = text;
+        nativeInput.dispatchEvent(new Event('input', { bubbles: true }));
+        return nativeInput;
+      };
+
+      const pressKey = async (page: SpecPage, key: string) => {
+        (page.root.querySelector('input') as HTMLInputElement).dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+        await page.waitForChanges();
+      };
+
+      it('removes the selected options one by one on Backspace', async () => {
+        const page = await createSelect('multiple="true" editable="true" option-value-key="value"', { options: objectOptions });
+        page.root.value = [1, 2, 3];
+        await page.waitForChanges();
+        const changes = listen(page, 'tk-change');
+
+        // the first press only aims at the last chip
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([1, 2, 3]);
+
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([1, 2]);
+
+        await pressKey(page, 'Backspace');
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([]);
+        expect(changes).toEqual([[1, 2], [1], []]);
+      });
+
+      it('keeps the typed filter text intact until the input is empty', async () => {
+        const page = await createSelect('multiple="true" editable="true" option-value-key="value"', { options: objectOptions });
+        page.root.value = [1, 2];
+        await page.waitForChanges();
+
+        typeInto(page, 'Th');
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([1, 2]);
+
+        typeInto(page, '');
+        await pressKey(page, 'Backspace');
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([1]);
+      });
+
+      it('removes the chip the arrow keys focused, resolved back through optionValueKey', async () => {
+        const page = await createSelect('multiple="true" editable="true" option-value-key="value"', { options: objectOptions });
+        page.root.value = [1, 2, 3];
+        await page.waitForChanges();
+
+        // the focus lands on "Three" and Backspace removes exactly that chip
+        await pressKey(page, 'ArrowLeft');
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([1, 2]);
+
+        // the focus stepped back onto "Two", which Delete then removes
+        await pressKey(page, 'Delete');
+        expect(page.root.value).toEqual([1]);
+      });
+
+      it('maps a removal back to the right value while the +N indicator is shown', async () => {
+        const page = await createSelect('multiple="true" editable="true" visible-item-count="2" option-value-key="value"', { options: objectOptions });
+        page.root.value = [1, 2, 3];
+        await page.waitForChanges();
+
+        // the last rendered chip is the +N indicator, which has no remove button: the focus steps
+        // over it onto "Two", and removing that maps back past the collapsed display
+        await pressKey(page, 'ArrowLeft');
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([1, 3]);
+
+        const plain = await createSelect('multiple="true" editable="true" visible-item-count="2" option-value-key="value"', { options: objectOptions });
+        plain.root.value = [1, 2, 3];
+        await plain.waitForChanges();
+
+        // a plain Backspace aims past the indicator the same way, then removes
+        await pressKey(plain, 'Backspace');
+        await pressKey(plain, 'Backspace');
+        expect(plain.root.value).toEqual([1, 3]);
+      });
+
+      it('clears the collapsed select-all chip but keeps disabled selections', async () => {
+        const page = await createSelect('multiple="true" editable="true" select-all="true" show-select-all-chip="true" option-value-key="value"', {
+          options: objectOptions,
+          optionDisabled: (item: any) => item.value === 3,
+        });
+        page.root.value = [1, 2, 3];
+        await page.waitForChanges();
+
+        await pressKey(page, 'Backspace');
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([3]);
+      });
+
+      it('never removes a disabled selection', async () => {
+        const page = await createSelect('multiple="true" editable="true" option-value-key="value"', {
+          options: objectOptions,
+          optionDisabled: (item: any) => item.value === 3,
+        });
+        page.root.value = [1, 3];
+        await page.waitForChanges();
+
+        // the last chip is the disabled one, so the keys step over it onto the removable chip
+        await pressKey(page, 'Backspace');
+        await pressKey(page, 'Backspace');
+        expect(page.root.value).toEqual([3]);
+
+        // with only the disabled selection left there is nothing for them to take
+        await pressKey(page, 'ArrowLeft');
+        await pressKey(page, 'Backspace');
+        await pressKey(page, 'Backspace');
+        await pressKey(page, 'Delete');
+        expect(page.root.value).toEqual([3]);
+      });
+
+      it('is ignored when the select is not editable or readonly', async () => {
+        const plain = await createSelect('multiple="true" option-value-key="value"', { options: objectOptions });
+        plain.root.value = [1, 2];
+        await plain.waitForChanges();
+        await pressKey(plain, 'Backspace');
+        await pressKey(plain, 'Backspace');
+        expect(plain.root.value).toEqual([1, 2]);
+
+        const readonly = await createSelect('multiple="true" editable="true" readonly="true" option-value-key="value"', { options: objectOptions });
+        readonly.root.value = [1, 2];
+        await readonly.waitForChanges();
+        await pressKey(readonly, 'Backspace');
+        await pressKey(readonly, 'Backspace');
+        expect(readonly.root.value).toEqual([1, 2]);
+      });
+    });
   });
 
   describe('input interactions', () => {


### PR DESCRIPTION
## Ne

`tk-input`'un chips modunda klavyeyle chip yönetimi. `tk-select`'te `editable` + `multiple` iken klavyeden hiçbir değer girilmemişken Backspace ile seçimlerin birer birer silinmesi talebi (TFI-2149) buradan karşılanıyor.

- Sol/sağ oklar chip'ler arasında yürüyor; son chip'ten sağa çıkınca metin alanına dönüyor, ilk chip'te duruyor.
- Backspace ve Delete odaklı chip'i siliyor; Backspace odağı bir öncekine taşıyor, Delete yerinde kalıp boşalan yere kayan chip'i devralıyor.
- Boş metin kutusundaki **ilk** Backspace yalnızca son chip'i hedefliyor; hiçbir chip gösterilmeden silinmiyor.
- X butonu olmayan chip'ler (disabled seçimler, `tk-select`'in `+N` ve readonly'deki "tümü" göstergeleri) hedeflenemiyor — klavye ile X butonu artık tek bir kuralı (`isChipRemovable`) paylaşıyor.
- Yazı varken, IME derlemesi sırasında, metinde seçim varken, `readonly`/`disabled` inputlarda ve `editable` olmayan select'lerde tuşlar metne ait kalıyor.

## Nasıl

Mantığın tamamı `tk-input`'ta: chip'leri ve native input'u o render ettiği için silme, mevcut `handleChipsRemove` → `tk-change` yolundan geçiyor. Bu sayede `tk-select` tarafında **tek satır değişiklik yok**; `visibleItemCount` yeniden sıralaması, "tümü" chip'i ve `optionValueKey` eşlemesi zaten o yoldaki mantıkla doğru çalışıyor.

`tk-chips`'e tek bir durum propu eklendi: `focused` (reflect). Halka chip'in kendi basılı-durum token'larını kullanıyor (primary `--primary-focus`, diğerleri `--secondary-focus`), böylece yarıçap ve renk chip'in kendi stilinde kalıyor. Chip odaktayken metin alanının imleci `caret-color: transparent` ile susuyor.

## Test

`tk-input` 24 → 35, `tk-select` 65 → 72 spec. Select testleri gerçek `KeyboardEvent` gönderip zinciri uçtan uca doğruluyor. Tüm core suite geçiyor, `tsc` temiz.

## Bilinen sınırlar

- Odaklanan chip için ARIA duyurusu yok (gerçek DOM focus / `aria-activedescendant` ayrı madde olarak planlandı).
- RTL'de oklar aynalanmıyor.
- Basılı tutulan Backspace her repeat'te bir chip siliyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)