### PR TITLE
ci(github): Add Claude Code PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,40 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Runs automatically on PR open/update, or on demand when someone
+    # comments "/code-review" on a PR.
+    if: >
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/code-review'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code-review.yml` — Claude Code reviews every PR automatically when it is opened/updated (drafts skipped), and on demand when someone comments `/code-review` on a PR.
- Findings are posted as inline review comments (or a single summary comment if nothing is found).

## Requirements
- Repository secret `CLAUDE_CODE_OAUTH_TOKEN` must exist (generated with `claude setup-token`).
- The **claude** GitHub App must have access to this repository.

## Test plan
- [ ] Merge, then open a test PR → a Claude review appears
- [ ] Comment `/code-review` on a PR → the workflow re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)