### PR TITLE
ci(github): Show full Claude output in review logs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: true
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"


### PR DESCRIPTION
Enables `show_full_output: true` on the Claude review workflow so API/auth errors are visible in the job log. Needed to diagnose the failing review on #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)