### PR TITLE
ci(github): Authenticate Claude review with subscription token

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           show_full_output: true
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"


### PR DESCRIPTION
Switches the Claude review workflow from `ANTHROPIC_API_KEY` to `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription), since the Console API account has no credit balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)