### PR TITLE
ci(github): Drop debug output flag from Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          show_full_output: true
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"


### PR DESCRIPTION
Removes `show_full_output: true`, added temporarily to diagnose the auth failure. Now that the review works, the flag only adds log noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)