### PR TITLE
fix(github): Allow Claude review to post its summary comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,4 +37,4 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh api:*)"'


### PR DESCRIPTION
The review run on #604 finished cleanly but posted nothing: `permission_denials_count: 1`. Only the inline-comment MCP tool was allowed, so the summary comment via `gh pr comment` was denied.

Adds `Bash(gh pr comment:*)` and `Bash(gh api:*)` to the allowed tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)