### PR TITLE
fix(github): Review PRs with a direct prompt instead of the plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,8 +34,20 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          show_full_output: true
-          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
-          plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.issue.number }}"
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh api:*)"'
+          prompt: |
+            Review the changes in pull request #${{ github.event.pull_request.number || github.event.issue.number }}
+            of ${{ github.repository }}.
+
+            Steps:
+            1. Run `gh pr diff ${{ github.event.pull_request.number || github.event.issue.number }}` to read the changes.
+            2. Read the repository's CLAUDE.md (if present) and follow its conventions.
+            3. Look for correctness bugs, missed edge cases, and clear violations of repo conventions.
+               Ignore pure style nits already handled by the linter.
+            4. For each concrete issue, leave an inline comment with
+               mcp__github_inline_comment__create_inline_comment.
+            5. Finally, post one summary comment with
+               `gh pr comment ${{ github.event.pull_request.number || github.event.issue.number }} --body "..."`.
+               If you found nothing, say so briefly in that comment.
+
+            You MUST post the summary comment before finishing. Do not use the Agent or Skill tools.
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*),Read,Grep,Glob"'


### PR DESCRIPTION
The `code-review` plugin skill does not work in the Action runtime: the run failed with `Error: Execute skill: code-review:code-review` and `Agent type 'haiku' not found`, then idled waiting on background agents and exited without posting anything (see #604).

Replaces the plugin with a direct review prompt and an explicit tool allowlist, so Claude reads the diff and posts inline plus summary comments itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)