### PR TITLE
feat(github): Add adversarial advanced PR review with verdict gate

### DIFF
--- a/.github/review-prompts/advanced-pr-review.md
+++ b/.github/review-prompts/advanced-pr-review.md
@@ -1,0 +1,241 @@
+# Advanced PR review — orchestrator process
+
+You are the orchestrator of an adversarial, lane-based PR review. The kit is
+three files in `.github/review-prompts/` — this one (your process),
+`agent-brief.md` (the shared mandate EVERY lane agent reads in full), and
+`lanes.md` (the lane catalog with required artefacts and standing questions).
+
+The harness staged `agent-brief.md` and `lanes.md` from `origin/develop` into
+the REVIEW KIT DIR named in your prompt — a PR cannot rewrite them there. Read
+both from that directory NOW, IN FULL, before anything else — the brief's rules
+bind you too. Never read the checkout's copies.
+
+## The one rule
+
+**Never stop at the diff boundary.** The diff tells you what changed; it does
+not tell you what breaks. Callers, unchanged sibling components, the unchanged
+file the hunk sits inside, and the three framework wrappers are where the
+findings are. Every instruction below is scaffolding around this.
+
+## What the harness already did (do not redo it)
+
+The workflow ran deterministic pre-analysis before you started. The HARVEST DATA
+section of your prompt contains:
+
+- **Effective diff size** (regenerated wrappers, lockfile, `components.d.ts` and
+  CHANGELOGs excluded). Judge scope on this number only — never on the raw size.
+- **Lane hints** derived mechanically from changed paths.
+- **Mechanical check results** (missing changeset, undocumented new prop,
+  hardcoded colour, new component without wrapper changes). Any hit listed there
+  is ALREADY a finding — carry it into the report verbatim; do not re-derive it.
+
+Start at the claim audit.
+
+## Phase C — Claim audit (lane 6 — you run this yourself, always)
+
+The PR description, commit messages and code comments are a LIST OF CLAIMS to be
+tested, not context to be trusted. Follow the lane 6 section of `lanes.md`:
+build the claim / TRUE / FALSE / OVERSTATED / evidence(`file:line`) table, watch
+for the three recurring shapes, and check whether the PR's own artefacts
+disagree with each other.
+
+Enumerable claims ("every", "all", "exactly one", "the only") immediately add
+lane 0 — they are falsified by ENUMERATION of the population, never by reading
+call sites.
+
+## Prior-review handling — report what was MISSED
+
+Check prior review comments (`gh pr view <n> --comments`). If any exist: **do
+not re-report what an existing review already raised; find what it MISSED.**
+Name overlap only when a prior finding is wrong or incomplete. Pass the
+already-covered list into every lane agent's prompt.
+
+If a prior ADVANCED review by this workflow exists, open your comment with
+Resolved / Still outstanding / New — and the new findings must carry a
+_different question_ than the previous pass.
+
+## Phase D — Hypotheses before code
+
+Per selected lane, write numbered FALSIFIABLE hypotheses from the description
+and harvest data alone — things that can die, with the consequence spelled out.
+Example of the proven form:
+
+> "The new `@Prop` is read in `componentWillLoad` only: if a consumer sets it
+> after mount, the component never re-reads it and silently shows the old value.
+> Find whether a `@Watch` exists; if not, state the failure and whether the PR
+> acknowledges it."
+
+A killed hypothesis is a result.
+
+## Time budget — publish partial over publishing nothing
+
+You have roughly **40 minutes of wall clock**; the harness kills the run after
+that. A killed run falls back to a script that publishes only the on-disk
+notebooks as a degraded partial with NO verdict. Manage the budget:
+
+- **Scale the fan-out to the effective size**: under ~300 effective lines → 2
+  lanes; ~300–1500 → 3; above → 4.
+- Launch lane subagents CONCURRENTLY in one message, never serially.
+- If lanes are slow, **consolidate and publish what has returned**, listing the
+  lanes not run in "Lanes run + limits". Publishing the comment is the one thing
+  that must happen.
+
+## Notebooks on disk — yours and the lanes'
+
+Your prompt names a LANE NOTES DIR. Maintain `<LANE NOTES DIR>/orchestrator.md`
+with the Write tool as you go: write the claim-audit table there the moment
+Phase C completes, and append consolidation notes as lanes return. Every lane
+agent maintains `<LANE NOTES DIR>/lane-<n>.md` the same way. If the run dies, a
+harness script publishes exactly these files — yours is what carries the claim
+audit, so write it early.
+
+## Phase E — Lane fan-out
+
+**Micro tier — skip the fan-out entirely** when ALL three hold: effective size
+under ~50 lines, zero lane hints, zero mechanical findings. Then you run the
+whole review yourself and publish with the same structure ("Lanes run + limits"
+states: micro tier, no lanes). Smallness alone never qualifies: a 20-line change
+to a public prop carries hints and takes the normal path.
+
+Otherwise select **2 to 4 lanes** from `lanes.md` using its cheat sheet, the
+harvest hints, the size rule above, and your reading of what the diff touches.
+The PR description may only ADD a lane, never remove one. One agent per coherent
+QUESTION — never per file.
+
+Fan out **one `general-purpose` Task subagent per lane**. Assemble each prompt
+in this order — the wording is the instrument, keep these elements verbatim
+where given:
+
+1. **Frame:** PR number, title, EFFECTIVE size, repo path. Add: "The author
+   asked for this review — be maximally harsh, not deferential."
+2. **Mandatory shared read:** "FIRST read IN FULL: `<KIT DIR>/agent-brief.md` —
+   mandate, base moves, output contract — and your lane's section of
+   `<KIT DIR>/lanes.md`. Follow them literally." Use the absolute REVIEW KIT DIR
+   paths from your prompt. This is what makes N agents behave like one reviewer.
+3. **Scope pin:** its lane's question only; name what sibling lanes cover;
+   "depth in your lane beats breadth across all of them."
+4. **Prior coverage:** the already-covered list; "do not re-report these — find
+   what they MISSED."
+5. **The lane's REQUIRED ARTEFACT**, restated. Non-negotiable.
+6. **The numbered hypotheses** from phase D for this lane.
+7. **Return contract:** "Return at most 15 lines: VERDICT plus finding headlines
+   with severity. Put the full artefact and findings in your final message
+   before the summary."
+8. **Notebook:** "Your LANE NOTES FILE is `<LANE NOTES DIR>/lane-<n>.md`.
+   Maintain it with the Write tool AS YOU WORK. If the run dies, that file is
+   the only part of your work that survives."
+
+Tell each agent what its siblings concluded only as: "a sibling concluded X;
+verify independently and say if you disagree" — never as settled fact.
+
+## Phase F — Consolidate
+
+- **Handle disagreement on method, not authority.** Prefer the lane that
+  enumerated the POPULATION over the lane that enumerated the MECHANISM — and
+  surface the disagreement instead of silently picking a winner.
+- Every finding carries: severity · CONFIRMED or PLAUSIBLE (never conflated — CI
+  here is static, so anything needing a browser stays PLAUSIBLE and names the
+  confirming run) · `file:line` · a CONCRETE failure scenario · an exposure
+  sentence · `Fix:` the smallest correct change, then stop. **You are the
+  reviewer, never the fixer.**
+- Collect every killed hypothesis into one "Checked and found FALSE" section.
+- Do not pad: three real findings beat twelve.
+
+## Phase H — Attack your own analysis
+
+If any finding at **MED or above** survives consolidation — regardless of
+verdict — spawn one final `general-purpose` subagent with this frame (naming the
+claims individually is what makes it work; a generic "critique this" produces
+agreement):
+
+> "Your object of study is the following review conclusions. Treat them as A
+> HYPOTHESIS TO BE ATTACKED, not as ground truth. The review claims: <list each
+> headline claim individually>. Verify each against the code and say plainly
+> where it is wrong, overstated, or an artefact of what the reviewers were told
+> to look for. Also hunt for one high-severity finding the consolidation may
+> have dropped. Ground every verdict in a `file:line`. Where the evidence is too
+> thin, say the claim is unsupported rather than hedging it."
+
+Fold its verdicts in before publishing — including downgrades. Zero-findings and
+LOW-only reviews skip this step.
+
+## Published comment — required structure
+
+```
+## Advanced review — PR #<n>
+
+<one-two sentence orientation: what the PR does and what this review focused on —
+NOT the verdict; the verdict comes last>
+
+### Claim audit
+<the claim table>
+
+### Findings (most severe first)
+[HIGH|MED|LOW] <one-line claim> — CONFIRMED | PLAUSIBLE
+- file:line · Failure scenario · Exposure · Fix: <smallest correct change>
+
+### Checked and found FALSE
+<killed hypotheses from all lanes, with what killed each>
+
+### Lanes run + limits
+<which lanes ran and why; any lane disagreement and how it was resolved; a coverage
+line: "N effective files changed · M examined across lanes · not examined: <list, or
+none>"; then state plainly: nothing requiring a browser was executed, and visual
+correctness was not assessed>
+
+### Verdict
+**APPROVE** | **CHANGES REQUESTED** — one-two sentences justifying it, naming the
+blocker when requesting changes.
+```
+
+The Verdict section is LAST (immediately before the metadata block) and the
+verdict word is bold.
+
+Post as ONE comment, ALWAYS via a body file: create the file with the Write
+tool, then `gh pr comment <n> --body-file <file>`. Never pass the body inline
+with `--body` — shell quoting mangles the JSON metadata block. The harness
+verifies the published comment contains every section above plus parseable
+metadata; a missing section fails the run.
+
+## Verdict block — mandatory
+
+Append this machine-readable block at the VERY END of the PR comment. It drives
+the merge gate and the auto-approve path — a missing or invalid block routes to
+human review:
+
+```
+<!-- REVIEW_METADATA
+{"verdict": "approve", "confidence": 0.0, "summary": "one sentence"}
+REVIEW_METADATA -->
+```
+
+Use `"verdict": "approve"` or `"changes_requested"` (it must match your prose
+verdict), and your real confidence between 0.0 and 1.0. FORMAT IS STRICT: an
+HTML comment wrapping a single-line JSON object, exactly as shown. A plain-text
+variant like `REVIEW_METADATA: verdict=approve` is INVALID.
+
+Verdict mapping: any CONFIRMED HIGH finding, or a mechanical-check finding from
+the harvest, ⇒ `changes_requested`. PLAUSIBLE-only findings may still approve
+when the confirming run is named and cheap for the author.
+
+## Telemetry block — optional, drives nothing
+
+After the metadata block, optionally append:
+
+```
+<!-- REVIEW_TELEMETRY
+{"run_id": <RUN ID from your prompt>, "effective_lines": 0, "lanes_run": ["<lane names>"], "micro_tier": false, "findings": {"high": 0, "med": 0, "low": 0}, "killed_hypotheses": 0, "phase_h_ran": false, "coverage": {"files_changed": 0, "files_examined": 0}}
+REVIEW_TELEMETRY -->
+```
+
+It gates nothing. If pressed for time, skip it rather than risk the mandatory
+block above it.
+
+## Anti-patterns (do not do these)
+
+- Do not prioritise or judge scope by raw diff size.
+- Do not re-read the same diff for a second pass without a different question.
+- Do not fix anything — every finding ends at `Fix:` and stops.
+- Do not present PLAUSIBLE as CONFIRMED.
+- Do not pad the findings list; do not soften because the author owns the repo.
+- Do not report style nits the linter already enforces.

--- a/.github/review-prompts/agent-brief.md
+++ b/.github/review-prompts/agent-brief.md
@@ -1,0 +1,113 @@
+# Lane agent brief — the shared mandate
+
+Every lane agent reads this file IN FULL before doing anything else. It binds
+the orchestrator too. It exists so that N agents behave like one reviewer with
+one standard, not N reviewers with N standards.
+
+## Your mandate
+
+You review one QUESTION about this pull request, in depth. You are not
+summarising the diff, not describing what changed, and not fixing anything. You
+are looking for what is WRONG, and proving it or killing it.
+
+The author asked for this review. Be maximally harsh, not deferential. A finding
+you soften into a suggestion is a finding the author will not act on.
+
+## The one rule
+
+**Never stop at the diff boundary.**
+
+The diff tells you what changed. It does not tell you what BREAKS. Those live
+in:
+
+- **Callers** of every changed function/component — `git grep` the symbol across
+  `packages/` and `docs/`, not just the file you were given.
+- **Unchanged siblings** — the other 41 components in
+  `packages/core/src/components/`. A pattern applied to one component and not
+  its siblings is either a fix that is missing elsewhere or an inconsistency
+  being introduced.
+- **The unchanged file the diff sits inside** — read the whole component, not
+  the changed hunk. Lifecycle methods, `@Watch` handlers, and
+  `disconnectedCallback` cleanup are usually outside the hunk and usually where
+  the bug is.
+- **The framework wrappers** — `packages/react`, `packages/vue`,
+  `packages/angular`. A core change that alters an event name, a prop type, or a
+  slot contract reaches three wrappers. Check whether it did.
+
+## Base moves — run these, do not just intend to
+
+1. **Enumerate the population, not the mechanism.** If a claim says "every
+   component does X", list every component and check. Claims with "all",
+   "every", "exactly one", "the only" are falsified by enumeration and nothing
+   else.
+2. **`git grep` the symbol.** Before accepting that a rename/signature change is
+   complete, grep the old name across the repo including `docs/` and `*.mdx`.
+3. **Read the whole component file**, not the hunk.
+4. **Check the test actually exercises the branch it names.** A test whose name
+   claims a behaviour but whose setup never reaches that code path is worse than
+   no test — it reports safety that does not exist. Trace the arming condition.
+5. **Diff the three wrappers against each other** when the core contract moves.
+
+## Severity
+
+- **HIGH** — data loss, a broken public API contract, a crash, an accessibility
+  regression that locks a control away from assistive tech, or a change that
+  breaks consumers on upgrade without a major version.
+- **MED** — a real defect with a bounded blast radius: one component, one
+  framework, one prop; an inconsistency this PR introduces; a missing cleanup
+  that leaks.
+- **LOW** — correctness-adjacent: a misleading name, dead code, a docs/string
+  mismatch, a redundant guard.
+
+## CONFIRMED vs PLAUSIBLE — never conflate them
+
+- **CONFIRMED** — you can point at the code that proves it. `file:line`, and the
+  reasoning is complete from what you read.
+- **PLAUSIBLE** — it requires execution, a browser, or a build to be certain.
+  Say so, and NAME the cheap confirming run
+  ("`pnpm --filter @takeoff-ui/core test` on `tk-input.e2e.ts:95`").
+
+CI here is static. Anything needing a running browser stays PLAUSIBLE.
+Presenting PLAUSIBLE as CONFIRMED is the single most damaging thing you can do
+to this review's credibility.
+
+## Every finding carries, without exception
+
+- severity · CONFIRMED or PLAUSIBLE
+- `file:line`
+- a CONCRETE failure scenario — real inputs, real sequence, real wrong output.
+  Not "this could cause issues".
+- an exposure sentence — who hits it and when. "Cannot be determined statically"
+  is an acceptable answer; silence is not.
+- `Fix:` the smallest correct change — then STOP. **You are the reviewer, never
+  the fixer.** Do not write the patch.
+
+## Killed hypotheses are results
+
+Everything you checked and found FINE goes in your report, with what killed it.
+A review with an empty "checked and found false" section did not look hard
+enough. It is also the only defence against the reader assuming you simply did
+not look.
+
+## Your notebook
+
+Your prompt names a LANE NOTES FILE. Maintain it with the Write tool AS YOU WORK
+— create it the moment your artefact takes shape, rewrite it on every finding
+and every killed hypothesis. If the run dies, that file is the only part of your
+work that survives. Do not save it for the end.
+
+## Return contract
+
+Return at most 15 lines to the orchestrator: your VERDICT line plus finding
+headlines with severity. Put the full artefact, the findings with all their
+required parts, and the killed hypotheses in your final message BEFORE that
+summary.
+
+## Anti-patterns
+
+- Do not describe the diff back to the reader.
+- Do not report a finding without a `file:line`.
+- Do not pad — three real findings beat twelve.
+- Do not fix, patch, or rewrite code.
+- Do not soften a finding because the author owns the repo.
+- Do not report style nits the linter already enforces.

--- a/.github/review-prompts/lanes.md
+++ b/.github/review-prompts/lanes.md
@@ -1,0 +1,170 @@
+# Lane catalog
+
+One agent per coherent QUESTION — never per file. Each lane below states its
+question, its REQUIRED ARTEFACT (non-negotiable: never paragraphs about a
+topic), and its standing questions.
+
+## Cheat sheet — which lanes to pick
+
+| The diff touches…                                           | Lanes                                  |
+| ----------------------------------------------------------- | -------------------------------------- |
+| `packages/core/src/components/**`                           | 1, plus 2 if the public contract moved |
+| `packages/{react,vue,angular}/**`                           | 2                                      |
+| `*.scss`, `*.css`, `packages/tailwind/**`, `global/`        | 3                                      |
+| `*.e2e.ts`, `*.spec.ts`, `__tests__/`                       | 4                                      |
+| `docs/**`, `*.mdx`, README                                  | 5                                      |
+| `package.json`, `turbo.json`, `.github/**`, `.changeset/**` | 6                                      |
+| A claim with "every", "all", "exactly one", "the only"      | 0 (always add)                         |
+
+Lane 6 (claim audit) is run by the ORCHESTRATOR itself, always, and is not
+fanned out.
+
+---
+
+## Lane 0 — Enumeration
+
+**Question:** is the enumerable claim actually true across the whole population?
+
+**Required artefact:** the full population as a list, each member marked holds /
+does-not-hold, with `file:line`.
+
+Add this lane whenever any claim in the PR description, a commit message, or a
+code comment quantifies over a set: "every component", "all wrappers", "the only
+place", "exactly one". These are falsified by ENUMERATION, never by reading the
+mechanism's call sites. Enumerate `packages/core/src/components/*/` when the
+population is components; enumerate the three wrapper packages when it is
+frameworks.
+
+---
+
+## Lane 1 — Component contract & lifecycle
+
+**Question:** does the component still behave correctly across its full
+lifecycle, and does its public surface still mean what consumers think it means?
+
+**Required artefact:** a table of every public `@Prop`, `@Event`, `@Method` and
+slot the diff touches — old contract → new contract → who breaks.
+
+Standing questions:
+
+- Is a `@Prop` type widened or narrowed? A narrowing is a breaking change for
+  consumers even when TypeScript in this repo still compiles.
+- Is an `@Event` renamed, or is its `detail` payload shape changed? Grep the
+  event name across all three wrappers and `docs/`.
+- Does `disconnectedCallback` clean up everything `connectedCallback` and
+  `componentDidLoad` set up — listeners, observers, timers, `document`-level
+  handlers? A missing removal leaks per mount/unmount cycle.
+- Do `@Watch` handlers fire on the initial render, and does the code assume they
+  do (or do not)?
+- Is state mutated in a way Stencil cannot see (mutating an array/object in
+  place rather than reassigning)? That renders stale.
+- Is a `@Prop({ mutable: true })` written from inside the component without an
+  accompanying event, so the consumer's binding silently desynchronises?
+- Keyboard and ARIA: is a control reachable by Tab, does a disabled control
+  announce why, does focus survive re-render?
+
+---
+
+## Lane 2 — Framework parity
+
+**Question:** does this change land identically in React, Vue and Angular — or
+does it silently land in one?
+
+**Required artefact:** a 3-column matrix (react / vue / angular) × the changed
+contract items, each cell: propagated / missing / N-A with `file:line`.
+
+Standing questions:
+
+- The wrappers under `stencil-generated/`, `packages/vue/lib/components.ts` and
+  the Angular `directives/` are BUILD OUTPUT (see `.gitignore`). If the PR
+  hand-edits them, that edit is erased on the next build — that is a finding.
+- Does a new component appear in each wrapper's public exports?
+- Event naming differs per framework binding (`onTkChange` vs `@tkChange` vs
+  `(tkChange)`). Does the docs example for each framework match what the wrapper
+  actually emits?
+- Does a new prop with a non-primitive type (object/array/function) cross the
+  wrapper boundary correctly, or does it need explicit serialisation?
+
+---
+
+## Lane 3 — Styling, theming & tokens
+
+**Question:** does this render correctly in every theme and density the design
+system supports, and does it respect the token layer?
+
+**Required artefact:** an inventory of every CSS custom property, class and
+hardcoded value the diff adds or changes, each marked token-backed / hardcoded /
+overridden.
+
+Standing questions:
+
+- Hardcoded hex/rgb values in component styles bypass theming. Is there an
+  existing token for this value? Grep `packages/tailwind` and the global styles.
+- Does a new style rule leak past its component (`:host` scoping, `::part`,
+  `::slotted`)? Stencil's scoping is not shadow DOM in every mode — check the
+  component's `shadow`/`scoped` setting before assuming isolation.
+- Does the change hold in dark mode and RTL if the repo supports them?
+- Is a `z-index` introduced without reference to the existing layering scale?
+- Does a specificity bump silently override a consumer's own override?
+
+---
+
+## Lane 4 — Test integrity
+
+**Question:** do these tests actually test what their names claim?
+
+**Required artefact:** a table — test name → the branch it claims to cover → the
+line that ARMS that branch → verdict (exercises it / passes vacuously).
+
+Standing questions:
+
+- Trace the arming condition for every new test. A test that sets state directly
+  when the production path only reaches that state through a user interaction is
+  passing vacuously: it would still pass with the feature deleted.
+- Would this test fail if the fix were reverted? If you cannot show the line
+  that would break, say so.
+- Is an assertion checking a default browser behaviour rather than the new code?
+- Are new e2e tests actually run by CI? Check the workflow that invokes them.
+- Does the PR change behaviour with NO test, while claiming coverage?
+
+---
+
+## Lane 5 — Docs & public API surface
+
+**Question:** does the documented API match the shipped API?
+
+**Required artefact:** a table — documented item → docs location → actual code →
+match / drift.
+
+Standing questions:
+
+- A new/changed `@Prop` with no docs page update is drift. So is a removed prop
+  still documented.
+- Do the framework-specific code examples in `docs/` compile against the new
+  contract?
+- Does the changeset (`.changeset/*.md`) describe the change at the right semver
+  level — a breaking contract change under a patch bump is a release hazard.
+- Are strings user-visible and localised where the repo expects it?
+
+---
+
+## Lane 6 — Claim audit (orchestrator runs this, always)
+
+**Question:** which claims made by this PR are false?
+
+**Required artefact:** a table — claim / TRUE / FALSE / OVERSTATED / evidence
+`file:line`.
+
+The PR description, commit messages and code comments are a LIST OF CLAIMS TO BE
+TESTED, not context to be trusted.
+
+Three recurring shapes to watch for:
+
+- **Overstated scope** — "fixes X for all components" when it fixes it for one.
+- **Unreachable justification** — a rationale that describes a state the code
+  cannot actually be in.
+- **Unsupported sequencing** — "A happens before B" with nothing enforcing the
+  order.
+
+Also check whether the PR's own artefacts disagree with each other: description
+vs changeset vs test names vs the code.

--- a/.github/scripts/advanced-review-harvest.sh
+++ b/.github/scripts/advanced-review-harvest.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Deterministic pre-analysis for the advanced PR review (runbook phases A+B).
+# Everything free-and-certain runs here, before any model:
+#   - effective diff size (regenerated artefacts excluded)
+#   - lane hints from changed paths
+#   - mechanical checks: missing changeset, cross-framework wrapper drift,
+#     new public prop without docs, hardcoded colour outside the token layer
+# Emits GitHub step outputs (effective_size, generated_size, total_size, lane_hints,
+# mechanical) and ::warning annotations for mechanical hits, so these findings surface
+# even if the model step fails.
+#
+# Usage: advanced-review-harvest.sh <pr-number>   (needs GH_TOKEN, a full checkout with
+# origin/develop fetched)
+set -euo pipefail
+
+PR_NUMBER="${1:?usage: advanced-review-harvest.sh <pr-number>}"
+OUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+FILES_JSON=$(gh pr view "$PR_NUMBER" --json files --jq '.files')
+
+# --- Phase A: effective size -------------------------------------------------
+# Generated/regenerated artefacts carry no review signal in this repo: the Stencil
+# output targets rewrite the framework wrappers wholesale on every build.
+GEN_RE='pnpm-lock\.yaml|components\.d\.ts|interfaces\.d\.ts|packages/vue/lib/components\.ts|packages/react/lib/components/stencil-generated/|packages/angular/projects/library/src/directives/|/dist/|__snapshots__|\.snap$|docs\.json|docs\.d\.ts|/llmstxt-files/|CHANGELOG\.md$'
+read -r GEN TOT <<<"$(jq -r --arg re "$GEN_RE" '
+  ([.[] | select(.path | test($re)) | .additions + .deletions] | add // 0) as $gen
+  | ([.[] | .additions + .deletions] | add // 0) as $tot
+  | "\($gen) \($tot)"' <<<"$FILES_JSON")"
+EFF=$((TOT - GEN))
+{
+  echo "generated_size=$GEN"
+  echo "total_size=$TOT"
+  echo "effective_size=$EFF"
+} >>"$OUT"
+echo "Diff size — total: $TOT, generated: $GEN, effective: $EFF"
+
+PATHS=$(jq -r '.[].path' <<<"$FILES_JSON")
+
+# --- Phase B: lane hints from paths -----------------------------------------
+# Descriptive hints only — the orchestrator may add lanes, never remove one because a
+# hint is absent.
+hints=""
+grep -qE 'packages/core/src/components/' <<<"$PATHS" && hints+="1-component-contract "
+grep -qE 'packages/(react|vue|angular)/' <<<"$PATHS" && hints+="2-framework-parity "
+grep -qE '\.(scss|css)$|packages/tailwind/|/global/|tokens' <<<"$PATHS" && hints+="3-styling-theming "
+grep -qE 'e2e|\.spec\.|__tests__|test/' <<<"$PATHS" && hints+="4-test-integrity "
+grep -qE '^docs/|\.mdx$|README' <<<"$PATHS" && hints+="5-docs-api "
+grep -qE 'package\.json$|turbo\.json|pnpm-workspace|\.github/|tsconfig' <<<"$PATHS" && hints+="6-build-release "
+echo "lane_hints=${hints:-none}" >>"$OUT"
+echo "Lane hints: ${hints:-none}"
+
+# --- Phase B: mechanical checks ----------------------------------------------
+MECH=""
+
+# 1. Publishable source changed without a changeset. The repo gates releases on
+#    changesets (changeset-check.yml); a missing one silently ships nothing.
+SRC_CHANGED=$(grep -E '^packages/(core|react|vue|angular|tailwind)/src/' <<<"$PATHS" | grep -vE '(test|spec|__tests__)' || true)
+CHANGESET_ADDED=$(grep -E '^\.changeset/.*\.md$' <<<"$PATHS" || true)
+LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(",")' || echo "")
+if [ -n "$SRC_CHANGED" ] && [ -z "$CHANGESET_ADDED" ] && ! grep -q 'skip-changelog' <<<"$LABELS"; then
+  MECH+="MISSING CHANGESET: publishable source changed but no .changeset/*.md was added (and no skip-changelog label)"$'\n'
+  echo "::warning::Publishable source changed with no changeset and no skip-changelog label"
+fi
+
+# 2. A new public @Prop on a core component with no matching docs page update.
+NEW_PROPS=$(gh pr diff "$PR_NUMBER" -- 'packages/core/src/components/**' 2>/dev/null \
+  | grep -E '^\+' | grep -oE '@Prop\(\)[[:space:]]+[a-zA-Z0-9_]+' \
+  | awk '{print $NF}' | sort -u || true)
+if [ -n "$NEW_PROPS" ]; then
+  DOCS_TOUCHED=$(grep -E '^docs/' <<<"$PATHS" || true)
+  if [ -z "$DOCS_TOUCHED" ]; then
+    for p in $NEW_PROPS; do
+      MECH+="NEW PROP UNDOCUMENTED: @Prop() $p added but no docs/ file changed in this PR"$'\n'
+      echo "::warning::New @Prop() $p added with no docs/ change"
+    done
+  fi
+fi
+
+# 3. Hardcoded hex colour added outside the token/theme layer.
+HEX_HITS=$(gh pr diff "$PR_NUMBER" -- 'packages/core/src/components/**' 2>/dev/null \
+  | grep -E '^\+' | grep -oE '#[0-9a-fA-F]{3,8}\b' | sort -u | head -5 || true)
+if [ -n "$HEX_HITS" ]; then
+  MECH+="HARDCODED COLOUR: $(echo "$HEX_HITS" | tr '\n' ' ')— added in component styles; the theme layer expects CSS variables"$'\n'
+  echo "::warning::Hardcoded colour(s) added in component styles: $(echo "$HEX_HITS" | tr '\n' ' ')"
+fi
+
+# 4. Core component added/removed without the framework wrappers following.
+#    The wrappers are generated, but their index/exports are committed.
+CORE_COMPONENT_FILES=$(grep -E '^packages/core/src/components/[^/]+/[^/]+\.tsx$' <<<"$PATHS" || true)
+if [ -n "$CORE_COMPONENT_FILES" ]; then
+  NEW_COMPONENT=$(gh pr diff "$PR_NUMBER" --name-status 2>/dev/null \
+    | awk '$1=="A"{print $2}' | grep -E '^packages/core/src/components/[^/]+/[^/]+\.tsx$' || true)
+  if [ -n "$NEW_COMPONENT" ]; then
+    WRAPPER_TOUCHED=$(grep -E '^packages/(react|vue|angular)/' <<<"$PATHS" || true)
+    if [ -z "$WRAPPER_TOUCHED" ]; then
+      MECH+="NEW COMPONENT, NO WRAPPER CHANGE: $(echo "$NEW_COMPONENT" | tr '\n' ' ')added but no packages/react|vue|angular file changed — check the wrappers export it"$'\n'
+      echo "::warning::New core component added with no framework wrapper change"
+    fi
+  fi
+fi
+
+{
+  echo "mechanical<<MECH_EOF"
+  echo "${MECH:-none}"
+  echo "MECH_EOF"
+} >>"$OUT"
+echo "Mechanical checks:"; echo "${MECH:-none}"

--- a/.github/scripts/risk-gate.sh
+++ b/.github/scripts/risk-gate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Deterministic risk gate for the advanced review's auto-approve path.
+#
+# Decides whether an AI-approved PR may additionally receive an automated GitHub
+# approval. Model output plays NO part in this decision — this is the hard
+# boundary that keeps the agent away from protected surfaces and from widening
+# its own permissions.
+#
+# Usage: risk-gate.sh <pr-number>
+#   exit 0 → eligible (summary on stdout)
+#   exit 1 → not eligible (one reason per line on stdout)
+#
+# Thresholds are overridable for experiments, not for bypass:
+#   RISK_GATE_MAX_LINES (default 300), RISK_GATE_MAX_FILES (default 15)
+set -euo pipefail
+
+PR="${1:?usage: risk-gate.sh <pr-number>}"
+MAX_LINES="${RISK_GATE_MAX_LINES:-300}"
+MAX_FILES="${RISK_GATE_MAX_FILES:-15}"
+
+# Paths where an unreviewed-by-human approval is never acceptable.
+PROTECTED_PATTERNS=(
+  '.github/'          # the agent must not widen its own cage
+  'package.json'      # dependency + publish config changes
+  'pnpm-lock.yaml'
+  'pnpm-workspace.yaml'
+  'turbo.json'
+  'tsconfig'
+  'Dockerfile'
+  '.env'
+  'packages/core/src/global/'   # theme/global side effects reach every component
+  'eslint.config'
+)
+
+PR_JSON=$(gh pr view "$PR" --json files,additions,deletions,headRefName,labels,isDraft)
+
+REASONS=()
+
+if [ "$(jq -r '.isDraft' <<<"$PR_JSON")" = "true" ]; then
+  REASONS+=("PR is a draft")
+fi
+
+FILE_COUNT=$(jq '.files | length' <<<"$PR_JSON")
+# Size is measured on PRODUCTION code only: tests lower risk, they don't raise
+# it. The file-count cap still counts every file.
+PROD_LINES=$(jq '[.files[]
+  | select((.path | test("(\\.spec\\.|\\.e2e\\.|__tests__/|(^|/)test/)")) | not)
+  | select((.path | test("(pnpm-lock\\.yaml|components\\.d\\.ts|stencil-generated/|CHANGELOG\\.md$)")) | not)
+  | .additions + .deletions] | add // 0' <<<"$PR_JSON")
+
+if [ "$PROD_LINES" -gt "$MAX_LINES" ]; then
+  REASONS+=("production diff is $PROD_LINES lines (cap $MAX_LINES)")
+fi
+if [ "$FILE_COUNT" -gt "$MAX_FILES" ]; then
+  REASONS+=("touches $FILE_COUNT files (cap $MAX_FILES)")
+fi
+
+PATHS=$(jq -r '.files[].path' <<<"$PR_JSON")
+for pat in "${PROTECTED_PATTERNS[@]}"; do
+  HIT=$(grep -F "$pat" <<<"$PATHS" || true)
+  if [ -n "$HIT" ]; then
+    REASONS+=("touches protected path matching '$pat': $(echo "$HIT" | head -3 | tr '\n' ' ')")
+  fi
+done
+
+# A PR carrying no changeset while changing publishable source is a release
+# hazard; never auto-approve it.
+SRC_CHANGED=$(grep -E '^packages/(core|react|vue|angular|tailwind)/src/' <<<"$PATHS" | grep -vE '(spec|e2e|__tests__|/test/)' || true)
+CHANGESET_ADDED=$(grep -E '^\.changeset/.*\.md$' <<<"$PATHS" || true)
+LABELS=$(jq -r '[.labels[].name] | join(",")' <<<"$PR_JSON")
+if [ -n "$SRC_CHANGED" ] && [ -z "$CHANGESET_ADDED" ] && ! grep -q 'skip-changelog' <<<"$LABELS"; then
+  REASONS+=("publishable source changed with no changeset and no skip-changelog label")
+fi
+
+if [ ${#REASONS[@]} -gt 0 ]; then
+  echo "NOT ELIGIBLE for automated approval:"
+  printf '  - %s\n' "${REASONS[@]}"
+  exit 1
+fi
+
+echo "ELIGIBLE for automated approval:"
+echo "  - production diff: $PROD_LINES lines (cap $MAX_LINES)"
+echo "  - files touched: $FILE_COUNT (cap $MAX_FILES)"
+echo "  - no protected path touched"
+echo "  - changeset present or explicitly skipped"
+exit 0

--- a/.github/workflows/advanced-pr-review.yml
+++ b/.github/workflows/advanced-pr-review.yml
@@ -1,0 +1,461 @@
+# Advanced PR Review — adversarial lane review
+#
+# Deterministic harvest/classify first, then an orchestrator that runs a claim audit,
+# fans out one Task subagent per lane, consolidates, and attacks its own analysis.
+# Process kit: .github/review-prompts/ — advanced-pr-review.md (orchestrator),
+# agent-brief.md (shared mandate every lane agent reads in full), lanes.md
+# (lane catalog: required artefacts + standing questions).
+#
+# TRIGGERS: the 'advanced-review' label, an "@claude advanced-review" PR comment, or
+# manual dispatch. The lightweight claude-code-review.yml keeps handling the automatic
+# per-PR reviews.
+#
+# MERGE GATE: the parsed verdict is published as commit status advanced-review/verdict
+# on the reviewed SHA. Make that status a required check in branch protection to turn
+# this into a real gate — approve → mergeable, changes_requested/invalid → blocked, and
+# every push invalidates the previous verdict (status is per-SHA; re-trigger to re-earn
+# it).
+#
+# AUTO-APPROVE: an approve verdict additionally runs .github/scripts/risk-gate.sh; only
+# a PR that clears the deterministic gate receives an automated GitHub approval.
+# Auto-merge stays behind the repo variable LOOP_AUTO_MERGE (default off).
+name: Advanced PR Review
+
+on:
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+
+concurrency:
+  group: advanced-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  advanced-review:
+    # The author_association gate keeps a long opus run behind org membership —
+    # contains() matches quoted text too, so anyone able to comment could otherwise
+    # trigger it. Bot guards prevent self-triggering.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'advanced-review') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude advanced-review') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
+       github.actor != 'dependabot[bot]' &&
+       github.actor != 'github-actions[bot]' &&
+       github.actor != 'claude[bot]')
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      # statuses:write — the verdict is published as the commit status
+      # advanced-review/verdict.
+      statuses: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history: the methodology crosses the diff boundary — git ls-tree
+          # origin/develop, sibling greps, and reading the kit from develop all need
+          # refs beyond the merge commit.
+          fetch-depth: 0
+
+      - name: Set PR number
+        id: pr-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUM="${{ github.event.inputs.pr_number }}"
+          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUM="${{ github.event.issue.number }}"
+          else
+            PR_NUM="${{ github.event.pull_request.number }}"
+          fi
+          echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
+          # Reviewing a merged/closed PR can only fail. Failing THIS step keeps every
+          # later step skipped, including the fail-safe (it requires this step's success).
+          STATE=$(gh pr view "$PR_NUM" --json state --jq .state)
+          if [ "$STATE" != "OPEN" ]; then
+            echo "::notice::PR #$PR_NUM is $STATE — nothing to review; ending the run."
+            gh run cancel "${{ github.run_id }}" || true
+            exit 1
+          fi
+          # The output-contract check only accepts comments newer than this — a stale
+          # advanced review from a previous round must not satisfy it.
+          echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          # Pin the head SHA under review NOW. The verdict status is stamped on this
+          # exact SHA — if the author pushes mid-run, the stale verdict lands on the old
+          # commit and correctly does NOT vouch for the new one.
+          echo "head_sha=$(gh pr view "$PR_NUM" --json headRefOid --jq .headRefOid)" >> "$GITHUB_OUTPUT"
+
+      # Visible acknowledgment — concurrency silently supersedes queued duplicate runs,
+      # so without this a re-mention during an active run looks like a broken trigger.
+      - name: Acknowledge trigger comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X POST "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content=eyes || true
+
+      # issue_comment and workflow_dispatch check out the DEFAULT branch, not the PR —
+      # switch to the PR head so file reads and greps see the code under review.
+      - name: Checkout PR head (comment/dispatch runs)
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout "${{ steps.pr-number.outputs.number }}"
+
+      # Runbook phases A+B: everything deterministic runs BEFORE any model. Mechanical
+      # hits are emitted as ::warning annotations, so they surface even if the model
+      # step fails.
+      - name: Harvest and classify (deterministic phases A+B)
+        id: harvest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Run develop's copy of the script, never the working tree's: develop is the
+          # trusted source, and a PR must not rewrite the rules that judge it.
+          git show origin/develop:.github/scripts/advanced-review-harvest.sh > "$RUNNER_TEMP/harvest.sh"
+          bash "$RUNNER_TEMP/harvest.sh" "${{ steps.pr-number.outputs.number }}"
+
+      # Stage all three kit files from origin/develop into RUNNER_TEMP — outside the
+      # checkout, so a PR cannot rewrite the rules that judge it. No fallback: if
+      # develop lacks a file, fail loud and let the terminal fail-safe route the PR.
+      - name: Stage review kit from origin/develop
+        id: kit
+        run: |
+          mkdir -p "$RUNNER_TEMP/review-kit"
+          for f in advanced-pr-review.md agent-brief.md lanes.md; do
+            git show "origin/develop:.github/review-prompts/$f" > "$RUNNER_TEMP/review-kit/$f"
+          done
+          echo "dir=$RUNNER_TEMP/review-kit" >> "$GITHUB_OUTPUT"
+          # Notebook dir: orchestrator + lane agents continuously write working state
+          # here. RUNNER_TEMP is per-JOB, so these files survive the model step's death
+          # and the fail-safe below can publish them.
+          mkdir -p "$RUNNER_TEMP/lane-notes"
+          echo "notes_dir=$RUNNER_TEMP/lane-notes" >> "$GITHUB_OUTPUT"
+          {
+            echo "orchestrator<<KIT_EOF"
+            cat "$RUNNER_TEMP/review-kit/advanced-pr-review.md"
+            echo "KIT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Advanced Claude Review
+        id: claude-review
+        # Step-level timeout below the job's cap: a job-level timeout cancels
+        # everything including always() steps, which would skip verdict routing and the
+        # fail-safe. A step timeout fails just this step and lets the tail run.
+        timeout-minutes: 45
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "github-actions,claude"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr-number.outputs.number }}
+
+            CRITICAL: Review the FINAL state of the code only.
+            Use `gh pr diff ${{ steps.pr-number.outputs.number }}` for the cumulative diff
+            against the base branch. Do NOT report issues from early commits that later
+            commits fixed; do NOT use individual commit diffs as the basis for bug reports.
+
+            HARVEST DATA (computed deterministically before this run — trust it, do not redo it):
+            - total diff: ${{ steps.harvest.outputs.total_size }} lines
+            - regenerated artefacts: ${{ steps.harvest.outputs.generated_size }} lines (ignore these files)
+            - EFFECTIVE diff: ${{ steps.harvest.outputs.effective_size }} lines — judge scope on this number only
+            - lane hints from changed paths: ${{ steps.harvest.outputs.lane_hints }}
+            - mechanical check results (each hit is already a finding — carry it into the report):
+            ${{ steps.harvest.outputs.mechanical }}
+
+            REVIEW KIT DIR: ${{ steps.kit.outputs.dir }}
+            agent-brief.md and lanes.md are staged there from origin/develop by the
+            harness — read them from that directory (NOT from the checkout, which a
+            PR could have edited), and point every subagent at the same absolute paths.
+
+            LANE NOTES DIR: ${{ steps.kit.outputs.notes_dir }}
+            You and every lane agent maintain notebooks there as you work. If this run
+            dies, a script publishes those files as a partial review — nothing else
+            survives.
+
+            RUN ID: ${{ github.run_id }} (for the optional telemetry block only)
+
+            YOUR PROCESS — follow these instructions literally:
+
+            ${{ steps.kit.outputs.orchestrator }}
+
+          # Task enables the lane fan-out (subagents); git grep/ls-tree/log/show power
+          # the boundary-crossing moves; Write lets the orchestrator build the comment
+          # body file for `gh pr comment --body-file` — without it the model falls back
+          # to inline --body, where the REVIEW_METADATA JSON dies on shell quoting.
+          claude_args: '--model opus --allowed-tools "Task,Write,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git show:*),Bash(git diff:*),Bash(git grep:*),Bash(git ls-tree:*),Bash(git log:*)"'
+          additional_permissions: |
+            actions: read
+
+      # The lane fan-out happens inside the model, so nothing in the Actions UI
+      # distinguishes a full multi-lane pass from one paragraph plus a valid verdict
+      # block. This check makes the output contract observable.
+      - name: Verify output contract
+        id: contract
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        run: |
+          # Pipe through real jq: gh's builtin --jq accepts no --arg flag.
+          BODY=$(gh pr view "$PR_NUMBER" --json comments | \
+            jq -r --arg since "${{ steps.pr-number.outputs.started_at }}" \
+            '[.comments[] | select((.body | contains("## Advanced review")) and .createdAt >= $since)] | last | .body // ""')
+          if [ -z "$BODY" ]; then
+            echo "::error::No advanced review comment was published by this run"
+            exit 1
+          fi
+          MISSING=""
+          for marker in "### Claim audit" "### Findings" "### Checked and found FALSE" "### Lanes run" "### Verdict" "<!-- REVIEW_METADATA"; do
+            case "$BODY" in
+              *"$marker"*) ;;
+              *) MISSING="$MISSING · $marker" ;;
+            esac
+          done
+          # The metadata must be parseable JSON, not just present.
+          METADATA=$(echo "$BODY" | sed -n '/<!-- REVIEW_METADATA/,/REVIEW_METADATA -->/p' | grep '^{' | head -1 || echo '')
+          if [ -z "$METADATA" ] || ! echo "$METADATA" | jq -e '.verdict | test("^(approve|changes_requested)$")' >/dev/null 2>&1; then
+            MISSING="$MISSING · valid REVIEW_METADATA JSON"
+          fi
+          if [ -n "$MISSING" ]; then
+            echo "::error::Advanced review output contract violated — missing:$MISSING"
+            exit 1
+          fi
+          echo "Output contract satisfied (all sections + parseable verdict present)."
+
+      - name: Remove advanced-review label
+        if: always() && github.event.action == 'labeled'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ steps.pr-number.outputs.number }} --remove-label "advanced-review" || true
+
+      - name: Parse review verdict
+        id: verdict
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        run: |
+          COMMENT_BODY=$(gh pr view "$PR_NUMBER" --json comments \
+            --jq '[.comments[] | select(.body | contains("REVIEW_METADATA"))] | last | .body // ""')
+          METADATA=$(echo "$COMMENT_BODY" | sed -n '/<!-- REVIEW_METADATA/,/REVIEW_METADATA -->/p' | grep '^{' | head -1 || echo '')
+
+          VERDICT=""
+          if [ -n "$METADATA" ] && echo "$METADATA" | jq empty 2>/dev/null; then
+            VERDICT=$(echo "$METADATA" | jq -r '.verdict // ""')
+          fi
+          # Fallback for the plain "REVIEW_METADATA: verdict=..." variant the model
+          # occasionally emits instead of the HTML-comment JSON block.
+          if [ -z "$VERDICT" ]; then
+            KV_LINE=$(echo "$COMMENT_BODY" | grep -E '^ *REVIEW_METADATA:' | head -1 || echo '')
+            if [ -n "$KV_LINE" ]; then
+              VERDICT=$(echo "$KV_LINE" | grep -oE 'verdict=(approve|changes_requested)' | head -1 | cut -d= -f2 || echo '')
+              [ -n "$VERDICT" ] && echo "::notice::Parsed key=value fallback format of REVIEW_METADATA"
+            fi
+          fi
+          # Defense-in-depth: anything but the two known verdicts routes to a human —
+          # prompt injection cannot invent a third state that merges.
+          case "$VERDICT" in
+            approve|changes_requested) ;;
+            *)
+              echo "::warning::Missing or invalid REVIEW_METADATA — routing to human review"
+              VERDICT="invalid"
+              ;;
+          esac
+          echo "verdict=$VERDICT" >> "$GITHUB_OUTPUT"
+
+      # Merge gate: publish the verdict as a commit status on the SHA that was
+      # reviewed. Make advanced-review/verdict a required check in branch protection
+      # to enforce it.
+      - name: Publish verdict as merge-gate status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          case "${{ steps.verdict.outputs.verdict }}" in
+            approve)
+              STATE=success; DESC="Advanced review approved this revision" ;;
+            changes_requested)
+              STATE=failure; DESC="Advanced review requests changes" ;;
+            *)
+              STATE=failure; DESC="No valid verdict — human review required" ;;
+          esac
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr-number.outputs.head_sha }}" \
+            -f state="$STATE" \
+            -f context="advanced-review/verdict" \
+            -f description="$DESC" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Ensure review labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "needs-human-review" --color "b60205" --description "Advanced review stopped — human decision required" || true
+          gh label create "ai-approved" --color "0e8a16" --description "Advanced review verdict approve + risk gate passed" || true
+
+      - name: Route invalid verdict to human review
+        if: steps.verdict.outputs.verdict == 'invalid'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "needs-human-review"
+          gh pr comment "$PR_NUMBER" --body "The advanced review did not produce a valid machine-readable verdict — routing to human review (fail-safe)."
+
+      - name: Run deterministic risk gate
+        id: gate
+        if: steps.verdict.outputs.verdict == 'approve'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        run: |
+          # Always run develop's copy, never the PR's — otherwise a PR could rewrite
+          # the rules that judge it. Fetched via the API: the claude-code-action step
+          # scrubs git credentials, so `git fetch` would fail with auth errors here.
+          gh api "repos/${{ github.repository }}/contents/.github/scripts/risk-gate.sh?ref=develop" \
+            --jq '.content' | base64 -d > "$RUNNER_TEMP/risk-gate.sh"
+          set +e
+          REPORT=$(bash "$RUNNER_TEMP/risk-gate.sh" "$PR_NUMBER")
+          STATUS=$?
+          set -e
+          echo "$REPORT"
+          if [ "$STATUS" -eq 0 ]; then
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo "report<<GATE_EOF"
+            echo "$REPORT"
+            echo "GATE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Auto-approve eligible PR
+        if: steps.gate.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+          GATE_REPORT: ${{ steps.gate.outputs.report }}
+          LOOP_AUTO_MERGE: ${{ vars.LOOP_AUTO_MERGE }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "ai-approved"
+
+          MERGE_STATE="disabled (repo variable LOOP_AUTO_MERGE)"
+          [ "${LOOP_AUTO_MERGE:-false}" = "true" ] && MERGE_STATE="enabled"
+
+          {
+            echo "Advanced review verdict: **approve** — deterministic risk gate passed."
+            echo ""
+            echo '```'
+            echo "$GATE_REPORT"
+            echo '```'
+            echo ""
+            echo "Auto-merge is ${MERGE_STATE} for this repository."
+          } > "$RUNNER_TEMP/approve-body.md"
+
+          gh pr review "$PR_NUMBER" --approve --body-file "$RUNNER_TEMP/approve-body.md" \
+            || echo "::warning::Could not submit approval (org may disallow Actions approvals) — the ai-approved label still marks eligibility"
+
+      - name: Route ineligible PR to human review
+        if: steps.gate.outputs.eligible == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+          GATE_REPORT: ${{ steps.gate.outputs.report }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "needs-human-review"
+          {
+            echo "Advanced review verdict was **approve**, but the deterministic risk gate requires a human:"
+            echo ""
+            echo '```'
+            echo "$GATE_REPORT"
+            echo '```'
+          } > "$RUNNER_TEMP/gate-body.md"
+          gh pr comment "$PR_NUMBER" --body-file "$RUNNER_TEMP/gate-body.md"
+
+      - name: Auto-merge (feature-flagged)
+        if: steps.gate.outputs.eligible == 'true' && vars.LOOP_AUTO_MERGE == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+        run: |
+          # --auto defers the merge until all REQUIRED branch-protection checks pass.
+          # Do NOT enable LOOP_AUTO_MERGE before develop's branch protection marks the
+          # real checks as required — without them --auto merges immediately.
+          if gh pr merge "$PR_NUMBER" --auto --squash; then
+            gh pr comment "$PR_NUMBER" --body "Auto-merge armed (squash) — will merge when all required checks pass."
+          else
+            echo "::warning::Could not arm auto-merge (missing branch protection or permissions)"
+          fi
+
+      # Terminal fail-safe: whatever killed the run, the PR must never be left silent.
+      # Salvage: the orchestrator and every lane agent write notebooks to the lane-notes
+      # dir. This step only FRAMES and POSTS them verbatim — no interpretation, and
+      # structurally no verdict: a dead run can never approve.
+      - name: Fail-safe — surface incomplete run
+        if: always() && steps.pr-number.outcome == 'success' && (steps.claude-review.outcome != 'success' || steps.contract.outcome != 'success')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
+          MECHANICAL: ${{ steps.harvest.outputs.mechanical }}
+          NOTES_DIR: ${{ steps.kit.outputs.notes_dir }}
+        run: |
+          {
+            echo "The advanced review did not complete (review step: ${{ steps.claude-review.outcome }}, output contract: ${{ steps.contract.outcome }})."
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo ""
+            echo "Deterministic pre-checks still ran — their findings:"
+            echo '```'
+            echo "${MECHANICAL:-none}"
+            echo '```'
+            if [ -n "$NOTES_DIR" ] && ls "$NOTES_DIR"/*.md >/dev/null 2>&1; then
+              echo ""
+              echo "### Salvaged notebooks (written before the run died — unconsolidated, NO VERDICT)"
+              for f in "$NOTES_DIR"/orchestrator.md "$NOTES_DIR"/lane-*.md; do
+                [ -f "$f" ] || continue
+                echo ""
+                echo "<details><summary>$(basename "$f")</summary>"
+                echo ""
+                # Scrub verdict markers from the untrusted notebook payload: a model may
+                # draft its final REVIEW_METADATA block in a notebook, and the verdict
+                # parser reads the LAST comment carrying that marker — an embedded draft
+                # must never be parseable as a real verdict on a later run.
+                head -c 8000 "$f" | sed -E 's/REVIEW_(METADATA|TELEMETRY)/DRAFT_\1/g'
+                [ "$(wc -c < "$f")" -gt 8000 ] && echo "" && echo "_…truncated (full file only existed on the runner)_"
+                echo ""
+                echo "</details>"
+              done
+            fi
+            echo ""
+            echo "Re-trigger with the \`advanced-review\` label or an \`@claude advanced-review\` comment."
+          } > "$RUNNER_TEMP/failsafe-body.md"
+          gh pr comment "$PR_NUMBER" --body-file "$RUNNER_TEMP/failsafe-body.md" \
+            || echo "::error::Could not post fail-safe comment"
+          # Merge gate fails CLOSED: an incomplete run marks the reviewed SHA with an
+          # error status so a required-status ruleset keeps the PR unmergeable.
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr-number.outputs.head_sha }}" \
+            -f state=error \
+            -f context="advanced-review/verdict" \
+            -f description="Advanced review did not complete — re-trigger it" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            || echo "::error::Could not publish error status"


### PR DESCRIPTION
Adds the full advanced-review system, ported from the tk-assistant implementation and adapted to this repo.

## What it is

A lane-based adversarial review that ends in a real decision, not just comments:

1. **Deterministic harvest** (`.github/scripts/advanced-review-harvest.sh`) runs before any model — effective diff size (generated wrappers/lockfile/CHANGELOGs excluded), lane hints from paths, and mechanical checks specific to this repo: missing changeset, new `@Prop` with no docs change, hardcoded colour in component styles, new core component with no wrapper change.
2. **Orchestrator** runs a claim audit, forms falsifiable hypotheses, then fans out 2–4 `Task` subagents — one per QUESTION, not per file.
3. **Lanes** (`.github/review-prompts/lanes.md`): enumeration · component contract & lifecycle · framework parity (react/vue/angular) · styling & tokens · test integrity · docs/API drift.
4. **Self-attack pass** — any MED+ finding gets one subagent whose job is to refute it.
5. **Verdict** — `APPROVE` / `CHANGES REQUESTED` plus a machine-readable `REVIEW_METADATA` block.

## The decision path

- Verdict is published as commit status **`advanced-review/verdict`** on the reviewed SHA. Making it a required check in branch protection turns it into a real merge gate.
- `approve` additionally runs a deterministic **risk gate** (`.github/scripts/risk-gate.sh`) — size caps, protected paths (`.github/`, `package.json`, lockfile, `global/`), changeset presence. Only a PR that clears it gets an automated GitHub approval.
- Anything else (invalid verdict, gate rejection, dead run) → `needs-human-review` label + a comment. **A dead run can never approve** — the fail-safe is structurally incapable of emitting a verdict.

## Triggers

The `advanced-review` label, an `@claude advanced-review` comment from an org member, or manual dispatch. The existing lightweight `claude-code-review.yml` keeps handling automatic per-PR reviews.

Model: `--model opus`.

## Not enabled by this PR

- Branch protection does not yet require `advanced-review/verdict` — that is a repo setting, deliberately left to a human.
- Auto-merge stays off behind the `LOOP_AUTO_MERGE` repo variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)